### PR TITLE
ToUpper won't work on mono

### DIFF
--- a/src/Core/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
+++ b/src/Core/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
@@ -68,7 +68,7 @@
 
             var includeAssemblies = (IncludeAssemblies() ?? Enumerable.Empty<string>());
             assemblies = assemblies.Concat(includeAssemblies)
-                .Select(a => a.ToUpperInvariant())
+                .Select(a => a.ToString())
                 .Where(a => !string.IsNullOrWhiteSpace(a))
                 .Distinct();
 


### PR DESCRIPTION
This was causing issues when trying to run on mono.
