### PR TITLE
Avoid loading duplicate assemblies on template compilation

### DIFF
--- a/src/Core/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
+++ b/src/Core/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
@@ -64,6 +64,7 @@
             var assemblies = CompilerServicesUtility
                 .GetLoadedAssemblies()
                 .Where(a => !a.IsDynamic)
+                .GroupBy(a => a.FullName).Select(grp => grp.First()) // only select distinct assemblies based on FullName to avoid loading duplicate assemblies
                 .Select(a => a.Location);
 
             var includeAssemblies = (IncludeAssemblies() ?? Enumerable.Empty<string>());


### PR DESCRIPTION
Only load distinct assemblies based on FullName from the assemblies loaded into the current AppDomain to avoid loading multiple instances of same assemblies and causing the compiler to fail.

This occurs in our case after a report is generated with Crystal Reports and two instances of the crdb_adoplus.dll assembly are loaded into the AppDomain from two different folders, but they are essentially the same assembly (by FullName).
