### PR TITLE
Support compiler-generated iterator classes as model

### DIFF
--- a/src/Core/RazorEngine.Core/Compilation/CompilerServiceBase.cs
+++ b/src/Core/RazorEngine.Core/Compilation/CompilerServiceBase.cs
@@ -75,10 +75,30 @@
             if (modelType == null)
                 throw new ArgumentException("The template type is a generic defintion, and no model type has been supplied.");
 
+            if (CompilerServicesUtility.IsIteratorType(modelType))
+            {
+                modelType = GetIteratorInterface(modelType);
+            }
+
             bool @dynamic = CompilerServicesUtility.IsDynamicType(modelType);
             Type genericType = templateType.MakeGenericType(modelType);
 
             return BuildTypeNameInternal(genericType, @dynamic);
+        }
+
+        private static Type GetIteratorInterface(Type modelType)
+        {
+            Type firstInterface = null;
+            foreach (var @interface in modelType.GetInterfaces())
+            {
+                if (firstInterface == null) 
+                    firstInterface = @interface;
+
+                if (@interface.IsGenericType)
+                    return @interface;
+            }
+
+            return @firstInterface ?? modelType;
         }
 
         /// <summary>

--- a/src/Core/RazorEngine.Core/Compilation/CompilerServicesUtility.cs
+++ b/src/Core/RazorEngine.Core/Compilation/CompilerServicesUtility.cs
@@ -7,6 +7,7 @@
     using System.Reflection;
     using System.Runtime.CompilerServices;
     using System.Text.RegularExpressions;
+    using System.Collections;
 
     /// <summary>
     /// Provides service methods for compilation.
@@ -16,6 +17,8 @@
         #region Fields
         private static readonly Type DynamicType = typeof(DynamicObject);
         private static readonly Type ExpandoType = typeof(ExpandoObject);
+        private static readonly Type EnumerableType = typeof(IEnumerable);
+        private static readonly Type EnumeratorType = typeof(IEnumerator);
         #endregion
 
         #region Methods
@@ -49,6 +52,21 @@
             return (DynamicType.IsAssignableFrom(type)
                     || ExpandoType.IsAssignableFrom(type)
                     || IsAnonymousType(type));
+        }
+
+        /// <summary>
+        /// Determines if the specified type is a compiler generated iterator type.
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <returns>True if the type is an iterator type, otherwise false.</returns>
+        public static bool IsIteratorType(Type type)
+        {
+            if (type == null)
+                throw new ArgumentNullException("type");
+
+            return type.IsNestedPrivate
+                && type.Name.StartsWith("<", StringComparison.Ordinal)
+                && (EnumerableType.IsAssignableFrom(type) || EnumeratorType.IsAssignableFrom(type));
         }
 
         /// <summary>

--- a/src/Core/Tests/RazorEngine.Core.Tests/TemplateServiceTestFixture.cs
+++ b/src/Core/Tests/RazorEngine.Core.Tests/TemplateServiceTestFixture.cs
@@ -111,6 +111,29 @@
         }
 
         /// <summary>
+        /// Tests that a simple template with an iterator model can be parsed.
+        /// </summary>
+        [Test]
+        public void TemplateService_CanParseSimpleTemplate_WithIteratorModel()
+        {
+            using (var service = new TemplateService())
+            {
+                const string template = "@foreach (var i in Model) { @i }";
+                const string expected = "One Two Three";
+
+                var model = CreateIterator("One ", "Two ", "Three");
+                string result = service.Parse(template, model);
+
+                Assert.That(result == expected, "Result does not match expected: " + result);
+            }
+        }
+
+        private static IEnumerable<T> CreateIterator<T>(params T[] items)
+        {
+            foreach (var item in items) yield return item;
+        }
+
+            /// <summary>
         /// Tests that a simple template with html-encoding can be parsed.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Fixed "Invalid Identifier" error when model is compiler-generated iterator type.
