### PR TITLE
Ensure assemblies exist on disk before including them as referenced assemblies for dynamic compliation

### DIFF
--- a/src/Core/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
+++ b/src/Core/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
@@ -63,7 +63,7 @@
 
             var assemblies = CompilerServicesUtility
                 .GetLoadedAssemblies()
-                .Where(a => !a.IsDynamic)
+                .Where(a => !a.IsDynamic && File.Exists(a.Location))
                 .GroupBy(a => a.FullName).Select(grp => grp.First()) // only select distinct assemblies based on FullName to avoid loading duplicate assemblies
                 .Select(a => a.Location);
 


### PR DESCRIPTION
Currently all loaded assemblies are included as reference assemblies as supplied for dynamic compilation. If any of the actual files are missing it will fail, even if that assembly was not required.  This could occur if an assembly has been removed from the GAC without rebooting the server.

This is a real problem that I experienced in a production system and caused all Razor templates to fail because a completely, totally, unrelated assembly was uninstalled.
