### PR TITLE
Overriding TemplateBase.RenderSection

### DIFF
--- a/src/Core/RazorEngine.Core/Templating/TemplateBase.cs
+++ b/src/Core/RazorEngine.Core/Templating/TemplateBase.cs
@@ -148,7 +148,7 @@ namespace RazorEngine.Templating
         /// <param name="name">The name of the section.</param>
         /// <param name="isRequired">Flag to specify whether the section is required.</param>
         /// <returns>The template writer helper.</returns>
-        public TemplateWriter RenderSection(string name, bool isRequired = true)
+        public virtual TemplateWriter RenderSection(string name, bool isRequired = true)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("The name of the section to render must be specified.");


### PR DESCRIPTION
Good day,

We recently implemented support for Razor templates in our content management system. Our original implementation (plain HTML templates with the custom scripting language on top) also supports layouts and sections and fits perfectly into what Razor provides so clients can basically take their templates from any MVC app and use them in our system with little to no modifications.

The issue is that we'd like to perform a custom logic inside TemplateBase.RenderSection method (we want to lookup our implementation-specific sections with the fall back to default behavior). Right now we added an overload to the method that takes additional parameter (again, implementation-specific). This argument is basically optional but without it the different overload gets called which is not under our control so right now clients have to pass "null" as the second argument which is redundant and requires changing the templates imported from MVC. 

We could probably shadow the original overload but that's not the way to go I think.

Can we have this little change in the master?

Best regards,
Pavel Volgarev
