### PR TITLE
Add support for debugging templates loaded from the disk

### DIFF
--- a/src/Core/RazorEngine.Core/Compilation/CSharp/CSharpRazorCodeLanguage.cs
+++ b/src/Core/RazorEngine.Core/Compilation/CSharp/CSharpRazorCodeLanguage.cs
@@ -37,7 +37,11 @@
         /// <returns>An instance of <see cref="RazorCodeGenerator"/>.</returns>
         public override RazorCodeGenerator CreateCodeGenerator(string className, string rootNamespaceName, string sourceFileName, RazorEngineHost host)
         {
-            return new CSharpRazorCodeGenerator(className, rootNamespaceName, sourceFileName, host, StrictMode);
+            return new CSharpRazorCodeGenerator(className, rootNamespaceName, sourceFileName, host, StrictMode)
+            {
+                // Generate line pragmas in order to allow debugging from Visual Studio
+                GenerateLinePragmas = true
+            };
         }
         #endregion
     }

--- a/src/Core/RazorEngine.Core/Compilation/CompilerServiceBase.cs
+++ b/src/Core/RazorEngine.Core/Compilation/CompilerServiceBase.cs
@@ -146,12 +146,18 @@
         /// </summary>
         /// <param name="className">The class name.</param>
         /// <param name="template">The template to compile.</param>
+        /// <param name="templateFileName">Name of the template file.</param>
         /// <param name="namespaceImports">The set of namespace imports.</param>
         /// <param name="templateType">The template type.</param>
         /// <param name="modelType">The model type.</param>
-        /// <returns>A <see cref="CodeCompileUnit"/> used to compile a type.</returns>
+        /// <returns>A <see cref="CodeCompileUnit" /> used to compile a type.</returns>
+        /// <exception cref="System.ArgumentException">
+        /// Class name is required.
+        /// or
+        /// Template is required.
+        /// </exception>
         [Pure]
-        public CodeCompileUnit GetCodeCompileUnit(string className, string template, ISet<string> namespaceImports, Type templateType, Type modelType)
+        public CodeCompileUnit GetCodeCompileUnit(string className, string template, string templateFileName, ISet<string> namespaceImports, Type templateType, Type modelType)
         {
             if (string.IsNullOrEmpty(className))
                 throw new ArgumentException("Class name is required.");
@@ -170,7 +176,7 @@
                 host.NamespaceImports.Add(ns);
 
             // Gets the generator result.
-            GeneratorResults result = GetGeneratorResult(host, template);
+            GeneratorResults result = GetGeneratorResult(host, template, templateFileName);
 
             // Add the dynamic model attribute if the type is an anonymous type.
             var type = result.GeneratedCode.Namespaces[0].Types[0];
@@ -191,13 +197,14 @@
         /// </summary>
         /// <param name="host">The razor engine host.</param>
         /// <param name="template">The template.</param>
+        /// <param name="templateFileName">Name of the template file.</param>
         /// <returns>The generator result.</returns>
-        private static GeneratorResults GetGeneratorResult(RazorEngineHost host, string template)
+        private static GeneratorResults GetGeneratorResult(RazorEngineHost host, string template, string templateFileName)
         {
             var engine = new RazorTemplateEngine(host);
             GeneratorResults result;
             using (var reader = new StringReader(template))
-                result = engine.GenerateCode(reader);
+                result = engine.GenerateCode(reader, null, null, templateFileName ?? "CustomTemplate");
 
             return result;
         }

--- a/src/Core/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
+++ b/src/Core/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
@@ -50,14 +50,14 @@
             if (_disposed)
                 throw new ObjectDisposedException(GetType().Name);
 
-            var compileUnit = GetCodeCompileUnit(context.ClassName, context.TemplateContent, context.Namespaces,
+            var compileUnit = GetCodeCompileUnit(context.ClassName, context.TemplateContent, context.TemplateFileName, context.Namespaces,
                                                  context.TemplateType, context.ModelType);
 
             var @params = new CompilerParameters
             {
                 GenerateInMemory = true,
                 GenerateExecutable = false,
-                IncludeDebugInformation = false,
+                IncludeDebugInformation = context.IncludeDebugInformation,
                 CompilerOptions = "/target:library /optimize"
             };
 

--- a/src/Core/RazorEngine.Core/Compilation/TypeContext.cs
+++ b/src/Core/RazorEngine.Core/Compilation/TypeContext.cs
@@ -41,6 +41,18 @@
         public string TemplateContent { get; set; }
 
         /// <summary>
+        /// Gets or sets the name of the template file.
+        /// </summary>
+        /// <value>The name of the template file.</value>
+        public string TemplateFileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include debug information into the generated template in order to support Visual Studio debugger inside the template code.
+        /// </summary>
+        /// <value><c>true</c> if [include debug information]; otherwise, <c>false</c>.</value>
+        public bool IncludeDebugInformation { get; set; }
+
+        /// <summary>
         /// Gets or sets the base template type.
         /// </summary>
         public Type TemplateType { get; set; }

--- a/src/Core/RazorEngine.Core/Razor.cs
+++ b/src/Core/RazorEngine.Core/Razor.cs
@@ -31,15 +31,35 @@
         }
         #endregion
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to include debug information into compiled templates to allow debugging of templates from Visual Studio.
+        /// </summary>
+        /// <value><c>true</c> to include debug information into compiled templates; otherwise, <c>false</c>.</value>
+        public static bool IncludeDebugInformation
+        {
+            get
+            {
+                return TemplateService.IncludeDebugInformation;
+            }
+
+            set
+            {
+                TemplateService.IncludeDebugInformation = value;
+            }
+        }
+
         #region Methods
         /// <summary>
         /// Compiles the specified template.
         /// </summary>
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="cacheName">The name of the template type in cache.</param>
-        public static void Compile(string razorTemplate, string cacheName)
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
+        public static void Compile(string razorTemplate, string cacheName, string razorTemplateFilePath = null)
         {
-            TemplateService.Compile(razorTemplate, null, cacheName);
+            TemplateService.Compile(razorTemplate, null, cacheName, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -48,9 +68,12 @@
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="modelType">The model type.</param>
         /// <param name="cacheName">The name of the template type in cache.</param>
-        public static void Compile(string razorTemplate, Type modelType, string cacheName)
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
+        public static void Compile(string razorTemplate, Type modelType, string cacheName, string razorTemplateFilePath = null)
         {
-            TemplateService.Compile(razorTemplate, modelType, cacheName);
+            TemplateService.Compile(razorTemplate, modelType, cacheName, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -59,10 +82,13 @@
         /// <typeparam name="T">The model type.</typeparam>
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="cacheName">The name of the template type in cache.</param>
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "We already provide a non-generic alternative.")]
-        public static void Compile<T>(string razorTemplate, string cacheName)
+        public static void Compile<T>(string razorTemplate, string cacheName, string razorTemplateFilePath = null)
         {
-            TemplateService.Compile(razorTemplate, typeof(T), cacheName);
+            TemplateService.Compile(razorTemplate, typeof(T), cacheName, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -72,7 +98,20 @@
         /// <returns>An instance of <see cref="ITemplate"/>.</returns>
         public static ITemplate CreateTemplate(string razorTemplate)
         {
-            return TemplateService.CreateTemplate(razorTemplate, null, null);
+            return TemplateService.CreateTemplate(razorTemplate, null, null, null);
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="ITemplate"/> from the specified string template.
+        /// </summary>
+        /// <param name="razorTemplate">The string template.</param>
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
+        /// <returns>An instance of <see cref="ITemplate"/>.</returns>
+        public static ITemplate CreateTemplate(string razorTemplate, string razorTemplateFilePath)
+        {
+            return TemplateService.CreateTemplate(razorTemplate, null, null, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -81,10 +120,13 @@
         /// <typeparam name="T">The model type.</typeparam>
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="model">The model instance.</param>
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <returns>An instance of <see cref="ITemplate{T}"/>.</returns>
-        public static ITemplate CreateTemplate<T>(string razorTemplate, T model)
+        public static ITemplate CreateTemplate<T>(string razorTemplate, T model, string razorTemplateFilePath = null)
         {
-            return TemplateService.CreateTemplate(razorTemplate, null, model);
+            return TemplateService.CreateTemplate(razorTemplate, null, model, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -96,22 +138,25 @@
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static IEnumerable<ITemplate> CreateTemplates(IEnumerable<string> razorTemplates, bool parallel = false)
         {
-            return TemplateService.CreateTemplates(razorTemplates, null, null, parallel);
+            return TemplateService.CreateTemplates(razorTemplates, null, null, null, parallel);
         }
 
         /// <summary>
         /// Creates a set of templates from the specified string templates and models.
         /// </summary>
         /// <typeparam name="T">The model type.</typeparam>
-        /// <param name="razorTemplates">The set of templates to create <see cref="ITemplate"/> instances for.</param>
+        /// <param name="razorTemplates">The set of templates to create <see cref="ITemplate" /> instances for.</param>
         /// <param name="models">The set of models used to assign to templates.</param>
+        /// <param name="razorTemplateFilePaths">The razor template file paths, in case the razorTemplates were loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <param name="parallel">Flag to determine whether to create templates in parallel.</param>
         /// <returns>The enumerable set of template instances.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
-        public static IEnumerable<ITemplate> CreateTemplates<T>(IEnumerable<string> razorTemplates, IEnumerable<T> models, bool parallel = false)
+        public static IEnumerable<ITemplate> CreateTemplates<T>(IEnumerable<string> razorTemplates, IEnumerable<T> models,  IEnumerable<string> razorTemplateFilePaths = null,  bool parallel = false)
         {
             List<object> modelList = (from m in models select (object)m).ToList();
-            return TemplateService.CreateTemplates(razorTemplates, null, modelList, parallel);
+            return TemplateService.CreateTemplates(razorTemplates, null, modelList, razorTemplateFilePaths, parallel);
         }
 
         /// <summary>
@@ -121,7 +166,7 @@
         /// <returns>An instance of <see cref="Type"/>.</returns>
         public static Type CreateTemplateType(string razorTemplate)
         {
-            return TemplateService.CreateTemplateType(razorTemplate, null);
+            return TemplateService.CreateTemplateType(razorTemplate, null, null);
         }
 
         /// <summary>
@@ -129,36 +174,45 @@
         /// </summary>
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="modelType">The model type.</param>
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <returns>An instance of <see cref="Type"/>.</returns>
-        public static Type CreateTemplateType(string razorTemplate, Type modelType)
+        public static Type CreateTemplateType(string razorTemplate, Type modelType, string razorTemplateFilePath = null)
         {
-            return TemplateService.CreateTemplateType(razorTemplate, modelType);
+            return TemplateService.CreateTemplateType(razorTemplate, modelType, razorTemplateFilePath);
         }
 
         /// <summary>
         /// Crates a set of template types from the specfied string templates.
         /// </summary>
-        /// <param name="razorTemplates">The set of templates to create <see cref="Type"/> instances for.</param>
+        /// <param name="razorTemplates">The set of templates to create <see cref="Type" /> instances for.</param>
+        /// <param name="razorTemplateFilePaths">The razor template file paths, in case the razorTemplates were loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <param name="parallel">Flag to determine whether to create template types in parallel.</param>
-        /// <returns>The set of <see cref="Type"/> instances.</returns>
+        /// <returns>The set of <see cref="Type" /> instances.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
-        public static IEnumerable<Type> CreateTemplateTypes(IEnumerable<string> razorTemplates, bool parallel = false)
+        public static IEnumerable<Type> CreateTemplateTypes(IEnumerable<string> razorTemplates, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false)
         {
-            return TemplateService.CreateTemplateTypes(razorTemplates, null, parallel);
+            return TemplateService.CreateTemplateTypes(razorTemplates, null, razorTemplateFilePaths, parallel);
         }
 
         /// <summary>
         /// Creates a set of template types from the specfied string templates.
         /// </summary>
-        /// <param name="razorTemplates">The set of templates to create <see cref="Type"/> instances for.</param>
+        /// <param name="razorTemplates">The set of templates to create <see cref="Type" /> instances for.</param>
         /// <param name="modelType">The model type.</param>
+        /// <param name="razorTemplateFilePaths">The razor template file paths, in case the razorTemplates were loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <param name="parallel">Flag to determine whether to create template types in parallel.</param>
-        /// <returns>The set of <see cref="Type"/> instances.</returns>
+        /// <returns>The set of <see cref="Type" /> instances.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
-        public static IEnumerable<Type> CreateTemplateTypes(IEnumerable<string> razorTemplates, Type modelType, bool parallel = false)
+        public static IEnumerable<Type> CreateTemplateTypes(IEnumerable<string> razorTemplates, Type modelType, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false)
         {
             IEnumerable<Type> modelTypes = Enumerable.Repeat<Type>(modelType, razorTemplates.Count());
-            return TemplateService.CreateTemplateTypes(razorTemplates, modelTypes, parallel);
+            return TemplateService.CreateTemplateTypes(razorTemplates, modelTypes, razorTemplateFilePaths, parallel);
         }
 
         /// <summary>
@@ -167,10 +221,13 @@
         /// </summary>
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="cacheName">The name of the template type in the cache.</param>
-        /// <returns>An instance of <see cref="ITemplate"/>.</returns>
-        public static ITemplate GetTemplate(string razorTemplate, string cacheName)
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
+        /// <returns>An instance of <see cref="ITemplate" />.</returns>
+        public static ITemplate GetTemplate(string razorTemplate, string cacheName, string razorTemplateFilePath)
         {
-            return TemplateService.GetTemplate(razorTemplate, null, cacheName);
+            return TemplateService.GetTemplate(razorTemplate, null, cacheName, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -181,10 +238,13 @@
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="model">The model instance.</param>
         /// <param name="cacheName">The name of the template type in the cache.</param>
-        /// <returns>An instance of <see cref="ITemplate{T}"/>.</returns>
-        public static ITemplate GetTemplate<T>(string razorTemplate, T model, string cacheName)
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
+        /// <returns>An instance of <see cref="ITemplate{T}" />.</returns>
+        public static ITemplate GetTemplate<T>(string razorTemplate, T model, string cacheName, string razorTemplateFilePath)
         {
-            return TemplateService.GetTemplate(razorTemplate, model, cacheName);
+            return TemplateService.GetTemplate(razorTemplate, model, cacheName, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -193,12 +253,15 @@
         /// </summary>
         /// <param name="razorTemplates">The set of templates to create.</param>
         /// <param name="cacheNames">The set of cache names.</param>
+        /// <param name="razorTemplateFilePaths">The razor template file paths, in case the razorTemplates were loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <param name="parallel">Flag to determine whether to get the templates in parallel.</param>
-        /// <returns>The set of <see cref="ITemplate"/> instances.</returns>
+        /// <returns>The set of <see cref="ITemplate" /> instances.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
-        public static IEnumerable<ITemplate> GetTemplates(IEnumerable<string> razorTemplates, IEnumerable<string> cacheNames, bool parallel = false)
+        public static IEnumerable<ITemplate> GetTemplates(IEnumerable<string> razorTemplates, IEnumerable<string> cacheNames, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false)
         {
-            return TemplateService.GetTemplates(razorTemplates, null, cacheNames, parallel);
+            return TemplateService.GetTemplates(razorTemplates, null, cacheNames, razorTemplateFilePaths, parallel);
         }
 
         /// <summary>
@@ -209,13 +272,16 @@
         /// <param name="razorTemplates">The set of templates to create.</param>
         /// <param name="models">The set of models.</param>
         /// <param name="cacheNames">The set of cache names.</param>
+        /// <param name="razorTemplateFilePaths">The razor template file paths, in case the razorTemplates were loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <param name="parallel">Flag to determine whether to get the templates in parallel.</param>
-        /// <returns>The set of <see cref="ITemplate"/> instances.</returns>
+        /// <returns>The set of <see cref="ITemplate" /> instances.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
-        public static IEnumerable<ITemplate> GetTemplates<T>(IEnumerable<string> razorTemplates, IEnumerable<T> models, IEnumerable<string> cacheNames, bool parallel = false)
+        public static IEnumerable<ITemplate> GetTemplates<T>(IEnumerable<string> razorTemplates, IEnumerable<T> models, IEnumerable<string> cacheNames, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false)
         {
             List<object> modelList = (from m in models select (object)m).ToList();
-            return TemplateService.GetTemplates(razorTemplates, modelList, cacheNames, parallel);
+            return TemplateService.GetTemplates(razorTemplates, modelList, cacheNames, razorTemplateFilePaths, parallel);
         }
 
         /// <summary>
@@ -225,7 +291,7 @@
         /// <returns>The string result of the template.</returns>
         public static string Parse(string razorTemplate)
         {
-            return TemplateService.Parse(razorTemplate, null, null, null);
+            return TemplateService.Parse(razorTemplate, null, null, null, null);
         }
 
         /// <summary>
@@ -237,7 +303,7 @@
         /// <returns>The string result of the template.</returns>
         public static string Parse(string razorTemplate, string cacheName)
         {
-            return TemplateService.Parse(razorTemplate, null, null, cacheName);
+            return TemplateService.Parse(razorTemplate, null, null, cacheName, null);
         }
 
         /// <summary>
@@ -248,7 +314,7 @@
         /// <returns>The string result of the template.</returns>
         public static string Parse(string razorTemplate, object model)
         {
-            return TemplateService.Parse(razorTemplate, model, null, null);
+            return TemplateService.Parse(razorTemplate, model, null, null, null);
         }
 
         /// <summary>
@@ -260,7 +326,7 @@
         /// <returns>The string result of the template.</returns>
         public static string Parse<T>(string razorTemplate, T model)
         {
-            return TemplateService.Parse(razorTemplate, model, null, null);
+            return TemplateService.Parse(razorTemplate, model, null, null, null);
         }
 
         /// <summary>
@@ -270,10 +336,13 @@
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="model">The model instance.</param>
         /// <param name="cacheName">The name of the template type in the cache or NULL if no caching is desired.</param>
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <returns>The string result of the template.</returns>
-        public static string Parse<T>(string razorTemplate, T model, string cacheName)
+        public static string Parse<T>(string razorTemplate, T model, string cacheName, string razorTemplateFilePath = null)
         {
-            return TemplateService.Parse(razorTemplate, model, null, cacheName);
+            return TemplateService.Parse(razorTemplate, model, null, cacheName, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -283,11 +352,14 @@
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="model">The model instance.</param>
         /// <param name="viewBag">The ViewBag contents or NULL for an initially empty ViewBag.</param>
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <param name="cacheName">The name of the template type in the cache or NULL if no caching is desired.</param>
         /// <returns>The string result of the template.</returns>
-        public static string Parse<T>(string razorTemplate, T model, DynamicViewBag viewBag, string cacheName)
+        public static string Parse<T>(string razorTemplate, T model, DynamicViewBag viewBag, string cacheName, string razorTemplateFilePath = null)
         {
-            return TemplateService.Parse(razorTemplate, model, viewBag, cacheName);
+            return TemplateService.Parse(razorTemplate, model, viewBag, cacheName, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -296,10 +368,13 @@
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="model">The model instance.</param>
         /// <param name="cacheName">The name of the template type in the cache or NULL if no caching is desired.</param>
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <returns>The string result of the template.</returns>
-        public static string Parse(string razorTemplate, object model, string cacheName)
+        public static string Parse(string razorTemplate, object model, string cacheName, string razorTemplateFilePath = null)
         {
-            return TemplateService.Parse(razorTemplate, model, null, cacheName);
+            return TemplateService.Parse(razorTemplate, model, null, cacheName, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -309,10 +384,13 @@
         /// <param name="model">The model instance.</param>
         /// <param name="viewBag">The ViewBag contents or NULL for an initially empty ViewBag.</param>
         /// <param name="cacheName">The name of the template type in the cache or NULL if no caching is desired.</param>
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <returns>The string result of the template.</returns>
-        public static string Parse(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName)
+        public static string Parse(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName, string razorTemplateFilePath = null)
         {
-            return TemplateService.Parse(razorTemplate, model, viewBag, cacheName);
+            return TemplateService.Parse(razorTemplate, model, viewBag, cacheName, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -334,7 +412,7 @@
                 throw new ArgumentException("Expected at least one entry in models list.");
 
             List<string> razorTemplateList = Enumerable.Repeat(razorTemplate, models.Count()).ToList();
-            return TemplateService.ParseMany(razorTemplateList, models, null, null, parallel);
+            return TemplateService.ParseMany(razorTemplateList, models, null, null, null, parallel);
         }
 
         /// <summary>
@@ -346,7 +424,7 @@
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static IEnumerable<string> ParseMany(IEnumerable<string> razorTemplates, bool parallel = false)
         {
-            return TemplateService.ParseMany(razorTemplates, null, null, null, parallel);
+            return TemplateService.ParseMany(razorTemplates, null, null, null, null, parallel);
         }
 
         /// <summary>
@@ -362,7 +440,7 @@
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static IEnumerable<string> ParseMany(IEnumerable<string> razorTemplates, IEnumerable<object> models, bool parallel = false)
         {
-            return TemplateService.ParseMany(razorTemplates, models, null, null, parallel);
+            return TemplateService.ParseMany(razorTemplates, models, null, null, null, parallel);
         }
 
         /// <summary>
@@ -378,7 +456,7 @@
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static IEnumerable<string> ParseMany(IEnumerable<string> razorTemplates, IEnumerable<string> cacheNames, bool parallel = false)
         {
-            return TemplateService.ParseMany(razorTemplates, null, null, cacheNames, parallel);
+            return TemplateService.ParseMany(razorTemplates, null, null, cacheNames, null, parallel);
         }
 
         /// <summary>
@@ -398,31 +476,28 @@
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static IEnumerable<string> ParseMany(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<string> cacheNames, bool parallel = false)
         {
-            return TemplateService.ParseMany(razorTemplates, models, null, cacheNames, parallel);
+            return TemplateService.ParseMany(razorTemplates, models, null, cacheNames, null, parallel);
         }
 
         /// <summary>
         /// Parses the specified set of templates.
         /// </summary>
         /// <param name="razorTemplates">The set of string templates to parse.</param>
-        /// <param name="models">
-        /// The set of models or NULL if no models exist for all templates.
-        /// Individual elements in this set may be NULL if no model exists for a specific template.
-        /// </param>
-        /// <param name="viewBags">
-        /// The set of initial ViewBag contents or NULL for an initially empty ViewBag for all templates.
-        /// Individual elements in this set may be NULL if an initially empty ViewBag is desired for a specific template.
-        /// </param>
-        /// <param name="cacheNames">
-        /// The set of cache names or NULL if no caching is desired for templates.
-        /// Individual elements in this set may be NULL if caching is not desired for a specific template.
-        /// </param>
+        /// <param name="models">The set of models or NULL if no models exist for all templates.
+        /// Individual elements in this set may be NULL if no model exists for a specific template.</param>
+        /// <param name="viewBags">The set of initial ViewBag contents or NULL for an initially empty ViewBag for all templates.
+        /// Individual elements in this set may be NULL if an initially empty ViewBag is desired for a specific template.</param>
+        /// <param name="cacheNames">The set of cache names or NULL if no caching is desired for templates.
+        /// Individual elements in this set may be NULL if caching is not desired for a specific template.</param>
+        /// <param name="razorTemplateFilePaths">The razor template file paths, in case the razorTemplates were loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <param name="parallel">Flag to determine whether parsing in templates.</param>
         /// <returns>The set of parsed template results.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
-        public static IEnumerable<string> ParseMany(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<DynamicViewBag> viewBags, IEnumerable<string> cacheNames, bool parallel = false)
+        public static IEnumerable<string> ParseMany(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<DynamicViewBag> viewBags, IEnumerable<string> cacheNames, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false)
         {
-            return TemplateService.ParseMany(razorTemplates, models, viewBags, cacheNames, parallel);
+            return TemplateService.ParseMany(razorTemplates, models, viewBags, cacheNames, razorTemplateFilePaths, parallel);
         }
 
         /// <summary>
@@ -446,7 +521,7 @@
 
             List<string> razorTemplateList = Enumerable.Repeat(razorTemplate, models.Count()).ToList();
             List<object> modelList = (from m in models select (object)m).ToList();
-            return TemplateService.ParseMany(razorTemplateList, modelList, null, null, parallel);
+            return TemplateService.ParseMany(razorTemplateList, modelList, null, null, null, parallel);
         }
 
         /// <summary>
@@ -464,7 +539,7 @@
         public static IEnumerable<string> ParseMany<T>(IEnumerable<string> razorTemplates, IEnumerable<T> models, bool parallel = false)
         {
             List<object> modelList = (from m in models select (object)m).ToList();
-            return TemplateService.ParseMany(razorTemplates, modelList, null, null, parallel);
+            return TemplateService.ParseMany(razorTemplates, modelList, null, null, null, parallel);
         }
 
         /// <summary>
@@ -486,7 +561,7 @@
         public static IEnumerable<string> ParseMany<T>(IEnumerable<string> razorTemplates, IEnumerable<T> models, IEnumerable<string> cacheNames, bool parallel = false)
         {
             List<object> modelList = (from m in models select (object)m).ToList();
-            return TemplateService.ParseMany(razorTemplates, modelList, null, cacheNames, parallel);
+            return TemplateService.ParseMany(razorTemplates, modelList, null, cacheNames, null, parallel);
         }
 
         /// <summary>
@@ -494,25 +569,22 @@
         /// </summary>
         /// <typeparam name="T">The model type.</typeparam>
         /// <param name="razorTemplates">The set of string templates to parse.</param>
-        /// <param name="models">
-        /// The set of models or NULL if no models exist for all templates.
-        /// Individual elements in this set may be NULL if no model exists for a specific template.
-        /// </param>
-        /// <param name="viewBags">
-        /// The set of initial ViewBag contents or NULL for an initially empty ViewBag for all templates.
-        /// Individual elements in this set may be NULL if an initially empty ViewBag is desired for a specific template.
-        /// </param>
-        /// <param name="cacheNames">
-        /// The set of cache names or NULL if no caching is desired for templates.
-        /// Individual elements in this set may be NULL if caching is not desired for a specific template.
-        /// </param>
+        /// <param name="models">The set of models or NULL if no models exist for all templates.
+        /// Individual elements in this set may be NULL if no model exists for a specific template.</param>
+        /// <param name="viewBags">The set of initial ViewBag contents or NULL for an initially empty ViewBag for all templates.
+        /// Individual elements in this set may be NULL if an initially empty ViewBag is desired for a specific template.</param>
+        /// <param name="cacheNames">The set of cache names or NULL if no caching is desired for templates.
+        /// Individual elements in this set may be NULL if caching is not desired for a specific template.</param>
+        /// <param name="razorTemplateFilePaths">The razor template file paths, in case the razorTemplates were loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <param name="parallel">Flag to determine whether parsing in templates.</param>
         /// <returns>The set of parsed template results.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
-        public static IEnumerable<string> ParseMany<T>(IEnumerable<string> razorTemplates, IEnumerable<T> models, IEnumerable<DynamicViewBag> viewBags, IEnumerable<string> cacheNames, bool parallel = false)
+        public static IEnumerable<string> ParseMany<T>(IEnumerable<string> razorTemplates, IEnumerable<T> models, IEnumerable<DynamicViewBag> viewBags, IEnumerable<string> cacheNames, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false)
         {
             List<object> modelList = (from m in models select (object)m).ToList();
-            return TemplateService.ParseMany(razorTemplates, modelList, viewBags, cacheNames, parallel);
+            return TemplateService.ParseMany(razorTemplates, modelList, viewBags, cacheNames, razorTemplateFilePaths, parallel);
         }
 
         /// <summary>

--- a/src/Core/RazorEngine.Core/Templating/ITemplateService.cs
+++ b/src/Core/RazorEngine.Core/Templating/ITemplateService.cs
@@ -15,6 +15,13 @@
         /// Gets the encoded string factory.
         /// </summary>
         IEncodedStringFactory EncodedStringFactory { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the compiled template will include debugging information necessary to allow debugging into templates from debugger.
+        /// </summary>
+        /// <value><c>true</c> if [include debug information]; otherwise, <c>false</c>.</value>
+        bool IncludeDebugInformation { get; set; }
+
         #endregion
 
         #region Methods
@@ -30,63 +37,66 @@
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="modelType">The model type.</param>
         /// <param name="cacheName">The name of the template type in the cache.</param>
-        void Compile(string razorTemplate, Type modelType, string cacheName);
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
+        void Compile(string razorTemplate, Type modelType, string cacheName, string razorTemplateFilePath = null);
 
         /// <summary>
-        /// Creates an instance of <see cref="ITemplate{T}"/> from the specified string template.
+        /// Creates an instance of <see cref="ITemplate{T}" /> from the specified string template.
         /// </summary>
-        /// <param name="razorTemplate">
-        /// The string template.
-        /// If templateType is not NULL (precompiled template), this parameter may be NULL (unused).
-        /// </param>
-        /// <param name="templateType">
-        /// The template type or NULL if the template type should be dynamically created.
-        /// If razorTemplate is not NULL, this parameter may be NULL (unused).
-        /// </param>
+        /// <param name="razorTemplate">The string template.
+        /// If templateType is not NULL (precompiled template), this parameter may be NULL (unused).</param>
+        /// <param name="templateType">The template type or NULL if the template type should be dynamically created.
+        /// If razorTemplate is not NULL, this parameter may be NULL (unused).</param>
         /// <param name="model">The model instance or NULL if no model exists.</param>
-        /// <returns>An instance of <see cref="ITemplate{T}"/>.</returns>
-        ITemplate CreateTemplate(string razorTemplate, Type templateType, object model);
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
+        /// <returns>An instance of <see cref="ITemplate{T}" />.</returns>
+        ITemplate CreateTemplate(string razorTemplate, Type templateType, object model, string razorTemplateFilePath = null);
 
         /// <summary>
         /// Creates a set of templates from the specified string templates.
         /// </summary>
-        /// <param name="razorTemplates">
-        /// The set of templates to create or NULL if all template types are already created (see templateTypes).
-        /// If this parameter is NULL, the the templateTypes parameter may not be NULL. 
-        /// Individual elements in this set may be NULL if the corresponding templateTypes[i] is not NULL (precompiled template).
-        /// </param>
-        /// <param name="models">
-        /// The set of models or NULL if no models exist for all templates.
-        /// Individual elements in this set may be NULL if no model exists for a specific template.
-        /// </param>
-        /// <param name="templateTypes">
-        /// The set of template types or NULL to dynamically create template types for each template.
-        /// If this parameter is NULL, the the razorTemplates parameter may not be NULL. 
-        /// Individual elements in this set may be NULL to dynamically create the template if the corresponding razorTemplates[i] is not NULL (dynamically compile template).
-        /// </param>
+        /// <param name="razorTemplates">The set of templates to create or NULL if all template types are already created (see templateTypes).
+        /// If this parameter is NULL, the the templateTypes parameter may not be NULL.
+        /// Individual elements in this set may be NULL if the corresponding templateTypes[i] is not NULL (precompiled template).</param>
+        /// <param name="templateTypes">The set of template types or NULL to dynamically create template types for each template.
+        /// If this parameter is NULL, the the razorTemplates parameter may not be NULL.
+        /// Individual elements in this set may be NULL to dynamically create the template if the corresponding razorTemplates[i] is not NULL (dynamically compile template).</param>
+        /// <param name="models">The set of models or NULL if no models exist for all templates.
+        /// Individual elements in this set may be NULL if no model exists for a specific template.</param>
+        /// <param name="razorTemplateFilePaths">The razor template file paths, in case the razorTemplates were loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <param name="parallel">Flag to determine whether to create templates in parallel.</param>
         /// <returns>The enumerable set of template instances.</returns>
-        IEnumerable<ITemplate> CreateTemplates(IEnumerable<string> razorTemplates, IEnumerable<Type> templateTypes, IEnumerable<object> models, bool parallel = false);
+        IEnumerable<ITemplate> CreateTemplates(IEnumerable<string> razorTemplates, IEnumerable<Type> templateTypes, IEnumerable<object> models, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false);
 
         /// <summary>
-        /// Creates a <see cref="Type"/> that can be used to instantiate an instance of a template.
+        /// Creates a <see cref="Type" /> that can be used to instantiate an instance of a template.
         /// </summary>
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="modelType">The model type or NULL if no model exists.</param>
-        /// <returns>An instance of <see cref="Type"/>.</returns>
-        Type CreateTemplateType(string razorTemplate, Type modelType);
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
+        /// <returns>An instance of <see cref="Type" />.</returns>
+        Type CreateTemplateType(string razorTemplate, Type modelType, string razorTemplateFilePath = null);
 
         /// <summary>
         /// Creates a set of template types from the specfied string templates.
         /// </summary>
-        /// <param name="razorTemplates">The set of templates to create <see cref="Type"/> instances for.</param>
-        /// <param name="modelTypes">
-        /// The set of model types or NULL if no models exist for all templates.
-        /// Individual elements in this set may be NULL if no model exists for a specific template.
-        /// </param>
+        /// <param name="razorTemplates">The set of templates to create <see cref="Type" /> instances for.</param>
+        /// <param name="modelTypes">The set of model types or NULL if no models exist for all templates.
+        /// Individual elements in this set may be NULL if no model exists for a specific template.</param>
+        /// <param name="razorTemplateFilePaths">The razor template file paths, in case the razorTemplates were loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <param name="parallel">Flag to determine whether to create template types in parallel.</param>
-        /// <returns>The set of <see cref="Type"/> instances.</returns>
-        IEnumerable<Type> CreateTemplateTypes(IEnumerable<string> razorTemplates, IEnumerable<Type> modelTypes, bool parallel = false);
+        /// <returns>The set of <see cref="Type" /> instances.</returns>
+        IEnumerable<Type> CreateTemplateTypes(IEnumerable<string> razorTemplates, IEnumerable<Type> modelTypes, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false);
 
         /// <summary>
         /// Gets an instance of the template using the cached compiled type, or compiles the template type
@@ -95,22 +105,26 @@
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="model">The model or NULL if there is no model for this template.</param>
         /// <param name="cacheName">The name of the template type in the cache.</param>
-        /// <returns>An instance of <see cref="ITemplate"/>.</returns>
-        ITemplate GetTemplate(string razorTemplate, object model, string cacheName);
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
+        /// <returns>An instance of <see cref="ITemplate" />.</returns>
+        ITemplate GetTemplate(string razorTemplate, object model, string cacheName, string razorTemplateFilePath = null);
 
         /// <summary>
         /// Gets the set of template instances for the specified string templates. Cached templates will be considered
         /// and if they do not exist, new types will be created and instantiated.
         /// </summary>
         /// <param name="razorTemplates">The set of templates to create.</param>
-        /// <param name="models">
-        /// The set of models or NULL if no models exist for all templates.
-        /// Individual elements in this set may be NULL if no model exists for a specific template.
-        /// </param>
+        /// <param name="models">The set of models or NULL if no models exist for all templates.
+        /// Individual elements in this set may be NULL if no model exists for a specific template.</param>
         /// <param name="cacheNames">The set of cache names.</param>
+        /// <param name="razorTemplateFilePaths">The razor template file paths, in case the razorTemplates were loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <param name="parallel">Flag to determine whether to get the templates in parallel.</param>
-        /// <returns>The set of <see cref="ITemplate"/> instances.</returns>
-        IEnumerable<ITemplate> GetTemplates(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<string> cacheNames, bool parallel = false);
+        /// <returns>The set of <see cref="ITemplate" /> instances.</returns>
+        IEnumerable<ITemplate> GetTemplates(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<string> cacheNames, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false);
 
         /// <summary>
         /// Returns whether or not a template by the specified name has been created already.
@@ -125,7 +139,7 @@
         /// <param name="cacheName">The name of the template type in cache.</param>
         /// <returns>Whether or not the template has been removed.</returns>
         bool RemoveTemplate(string cacheName);
-        
+
         /// <summary>
         /// Parses and returns the result of the specified string template.
         /// </summary>
@@ -133,8 +147,11 @@
         /// <param name="model">The model instance or NULL if no model exists.</param>
         /// <param name="viewBag">The ViewBag contents or NULL for an initially empty ViewBag.</param>
         /// <param name="cacheName">The name of the template type in the cache or NULL if no caching is desired.</param>
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <returns>The string result of the template.</returns>
-        string Parse(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName);
+        string Parse(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName, string razorTemplateFilePath = null);
 
         /// <summary>
         /// Parses and returns the result of the specified string template.
@@ -144,28 +161,28 @@
         /// <param name="model">The model instance or NULL if no model exists.</param>
         /// <param name="viewBag">The ViewBag contents or NULL for an initially empty ViewBag.</param>
         /// <param name="cacheName">The name of the template type in the cache or NULL if no caching is desired.</param>
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <returns>The string result of the template.</returns>
-        string Parse<T>(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName);
+        string Parse<T>(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName, string razorTemplateFilePath = null);
 
         /// <summary>
         /// Parses the specified set of templates.
         /// </summary>
         /// <param name="razorTemplates">The set of string templates to parse.</param>
-        /// <param name="models">
-        /// The set of models or NULL if no models exist for all templates.
-        /// Individual elements in this set may be NULL if no model exists for a specific template.
-        /// </param>
-        /// <param name="viewBags">
-        /// The set of initial ViewBag contents or NULL for an initially empty ViewBag for all templates.
-        /// Individual elements in this set may be NULL if an initially empty ViewBag is desired for a specific template.
-        /// </param>
-        /// <param name="cacheNames">
-        /// The set of cache names or NULL if no caching is desired for templates.
-        /// Individual elements in this set may be NULL if caching is not desired for a specific template.
-        /// </param>
+        /// <param name="models">The set of models or NULL if no models exist for all templates.
+        /// Individual elements in this set may be NULL if no model exists for a specific template.</param>
+        /// <param name="viewBags">The set of initial ViewBag contents or NULL for an initially empty ViewBag for all templates.
+        /// Individual elements in this set may be NULL if an initially empty ViewBag is desired for a specific template.</param>
+        /// <param name="cacheNames">The set of cache names or NULL if no caching is desired for templates.
+        /// Individual elements in this set may be NULL if caching is not desired for a specific template.</param>
+        /// <param name="razorTemplateFilePaths">The razor template file paths, in case the razorTemplates were loaded from a
+        /// location on the disk, It allows to debug the template from a debugger (step-in, set breakpoints...etc.). 
+        /// Note that order to fully allow debugging, <see cref="IncludeDebugInformation"/> must be set to <c>true</c>.</param>
         /// <param name="parallel">Flag to determine whether parsing in templates.</param>
         /// <returns>The set of parsed template results.</returns>
-        IEnumerable<string> ParseMany(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<DynamicViewBag> viewBags, IEnumerable<string> cacheNames, bool parallel);
+        IEnumerable<string> ParseMany(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<DynamicViewBag> viewBags, IEnumerable<string> cacheNames, IEnumerable<string> razorTemplateFilePaths, bool parallel);
 
         /// <summary>
         /// Resolves the template with the specified name.

--- a/src/Core/RazorEngine.Core/Templating/IsolatedTemplateService.cs
+++ b/src/Core/RazorEngine.Core/Templating/IsolatedTemplateService.cs
@@ -105,6 +105,23 @@
         /// Gets the encoded string factory.
         /// </summary>
         IEncodedStringFactory ITemplateService.EncodedStringFactory { get { return null; } }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the compiled template will include debugging information necessary to allow debugging into templates from debugger.
+        /// </summary>
+        /// <value><c>true</c> if [include debug information]; otherwise, <c>false</c>.</value>
+        public bool IncludeDebugInformation
+        {
+            get
+            {
+                return _proxy.IncludeDebugInformation;
+            }
+            set
+            {
+                _proxy.IncludeDebugInformation = value;
+            }
+        }
+
         #endregion
 
         #region Methods
@@ -123,9 +140,10 @@
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="modelType">The model type.</param>
         /// <param name="cacheName">The name of the template type in the cache.</param>
-        public void Compile(string razorTemplate, Type modelType, string cacheName)
+        /// <param name="razorTemplateFilePath"></param>
+        public void Compile(string razorTemplate, Type modelType, string cacheName, string razorTemplateFilePath = null)
         {
-            _proxy.Compile(razorTemplate, modelType, cacheName);
+            _proxy.Compile(razorTemplate, modelType, cacheName, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -158,7 +176,7 @@
         /// </param>
         /// <param name="model">The model instance or NULL if no model exists.</param>
         /// <returns>An instance of <see cref="ITemplate{T}"/>.</returns>
-        public ITemplate CreateTemplate(string razorTemplate, Type templateType, object model)
+        public ITemplate CreateTemplate(string razorTemplate, Type templateType, object model, string razorTemplateFilePath = null)
         {
             if (disposed)
                 throw new ObjectDisposedException("IsolatedTemplateService");
@@ -169,7 +187,7 @@
                     throw new ArgumentException("IsolatedTemplateService instances do not support anonymous or dynamic types.");
             }
 
-            return _proxy.CreateTemplate(razorTemplate, templateType, model);
+            return _proxy.CreateTemplate(razorTemplate, templateType, model, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -191,7 +209,7 @@
         /// </param>
         /// <param name="parallel">Flag to determine whether to create templates in parallel.</param>
         /// <returns>The enumerable set of template instances.</returns>
-        public IEnumerable<ITemplate> CreateTemplates(IEnumerable<string> razorTemplates, IEnumerable<Type> templateTypes, IEnumerable<object> models, bool parallel = false)
+        public IEnumerable<ITemplate> CreateTemplates(IEnumerable<string> razorTemplates, IEnumerable<Type> templateTypes, IEnumerable<object> models, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false)
         {
             if (disposed)
                 throw new ObjectDisposedException("IsolatedTemplateService");
@@ -208,16 +226,20 @@
                 }
             }
 
-            return _proxy.CreateTemplates(razorTemplates, templateTypes, models, parallel);
+            return _proxy.CreateTemplates(razorTemplates, templateTypes, models, razorTemplateFilePaths, parallel);
         }
 
         /// <summary>
-        /// Creates a <see cref="Type"/> that can be used to instantiate an instance of a template.
+        /// Creates a <see cref="Type" /> that can be used to instantiate an instance of a template.
         /// </summary>
         /// <param name="razorTemplate">The string template.</param>
         /// <param name="modelType">The model type or NULL if no model exists.</param>
-        /// <returns>An instance of <see cref="Type"/>.</returns>
-        public Type CreateTemplateType(string razorTemplate, Type modelType)
+        /// <param name="razorTemplateFilePath">The razor template file path, in case the razorTemplate was loaded from a
+        /// location on the disk, It allows to specifies a path to it in order to be able to debug directly the template inside.</param>
+        /// <returns>An instance of <see cref="Type" />.</returns>
+        /// <exception cref="System.ObjectDisposedException">IsolatedTemplateService</exception>
+        /// <exception cref="System.ArgumentException">IsolatedTemplateService instances do not support anonymous or dynamic types.</exception>
+        public Type CreateTemplateType(string razorTemplate, Type modelType, string razorTemplateFilePath = null)
         {
             if (disposed)
                 throw new ObjectDisposedException("IsolatedTemplateService");
@@ -225,7 +247,7 @@
             if (CompilerServicesUtility.IsDynamicType(modelType))
                 throw new ArgumentException("IsolatedTemplateService instances do not support anonymous or dynamic types.");
 
-            return _proxy.CreateTemplateType(razorTemplate, modelType);
+            return _proxy.CreateTemplateType(razorTemplate, modelType, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -238,7 +260,7 @@
         /// </param>
         /// <param name="parallel">Flag to determine whether to create template types in parallel.</param>
         /// <returns>The set of <see cref="Type"/> instances.</returns>
-        public IEnumerable<Type> CreateTemplateTypes(IEnumerable<string> razorTemplates, IEnumerable<Type> modelTypes, bool parallel = false)
+        public IEnumerable<Type> CreateTemplateTypes(IEnumerable<string> razorTemplates, IEnumerable<Type> modelTypes, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false)
         {
             if (disposed)
                 throw new ObjectDisposedException("IsolatedTemplateService");
@@ -252,7 +274,7 @@
                 }
             }
 
-            return _proxy.CreateTemplateTypes(razorTemplates, modelTypes, parallel);
+            return _proxy.CreateTemplateTypes(razorTemplates, modelTypes, razorTemplateFilePaths, parallel);
         }
 
         /// <summary>
@@ -290,12 +312,12 @@
         /// <param name="model">The model or NULL if there is no model for this template.</param>
         /// <param name="cacheName">The name of the template type in the cache.</param>
         /// <returns>An instance of <see cref="ITemplate"/>.</returns>
-        public ITemplate GetTemplate(string razorTemplate, object model, string cacheName)
+        public ITemplate GetTemplate(string razorTemplate, object model, string cacheName, string razorTemplateFilePath = null)
         {
             if (disposed)
                 throw new ObjectDisposedException("IsolatedTemplateService");
 
-            return _proxy.GetTemplate(razorTemplate, model, cacheName);
+            return _proxy.GetTemplate(razorTemplate, model, cacheName, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -310,7 +332,7 @@
         /// <param name="cacheNames">The set of cache names.</param>
         /// <param name="parallel">Flag to determine whether to get the templates in parallel.</param>
         /// <returns>The set of <see cref="ITemplate"/> instances.</returns>
-        public IEnumerable<ITemplate> GetTemplates(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<string> cacheNames, bool parallel = false)
+        public IEnumerable<ITemplate> GetTemplates(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<string> cacheNames, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false)
         {
             if (disposed)
                 throw new ObjectDisposedException("IsolatedTemplateService");
@@ -327,7 +349,7 @@
                 }
             }
 
-            return _proxy.GetTemplates(razorTemplates, models, cacheNames, parallel);
+            return _proxy.GetTemplates(razorTemplates, models, cacheNames, razorTemplateFilePaths, parallel);
         }
 
         /// <summary>
@@ -358,7 +380,7 @@
         /// <param name="viewBag">The ViewBag contents or NULL for an initially empty ViewBag.</param>
         /// <param name="cacheName">The name of the template type in the cache or NULL if no caching is desired.</param>
         /// <returns>The string result of the template.</returns>
-        public string Parse(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName)
+        public string Parse(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName, string razorTemplateFilePath = null)
         {
             if (disposed)
                 throw new ObjectDisposedException("IsolatedTemplateService");
@@ -369,7 +391,7 @@
                 throw new ArgumentException("IsolatedTemplateService instances do not support anonymous or dynamic types.");
             }
 
-           return _proxy.Parse(razorTemplate, model, viewBag, cacheName);
+            return _proxy.Parse(razorTemplate, model, viewBag, cacheName, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -380,7 +402,7 @@
         /// <param name="viewBag">The ViewBag contents or NULL for an initially empty ViewBag.</param>
         /// <param name="cacheName">The name of the template type in the cache or NULL if no caching is desired.</param>
         /// <returns>The string result of the template.</returns>
-        public string Parse<T>(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName)
+        public string Parse<T>(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName, string razorTemplateFilePath = null)
         {
             if (disposed)
                 throw new ObjectDisposedException("IsolatedTemplateService");
@@ -391,7 +413,7 @@
                     throw new ArgumentException("IsolatedTemplateService instances do not support anonymous or dynamic types.");
             }
 
-            return _proxy.Parse<T>(razorTemplate, model, viewBag, cacheName);
+            return _proxy.Parse<T>(razorTemplate, model, viewBag, cacheName, razorTemplateFilePath);
         }
 
         /// <summary>
@@ -412,7 +434,7 @@
         /// </param>
         /// <param name="parallel">Flag to determine whether parsing in templates.</param>
         /// <returns>The set of parsed template results.</returns>
-        public IEnumerable<string> ParseMany(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<DynamicViewBag> viewBags, IEnumerable<string> cacheNames, bool parallel)
+        public IEnumerable<string> ParseMany(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<DynamicViewBag> viewBags, IEnumerable<string> cacheNames,IEnumerable<string> razorTemplateFilePaths, bool parallel)
         {
             if (disposed)
                 throw new ObjectDisposedException("IsolatedTemplateService");
@@ -435,7 +457,7 @@
                 }
             }
 
-            return _proxy.ParseMany(razorTemplates, models, viewBags, cacheNames, parallel).ToList();
+            return _proxy.ParseMany(razorTemplates, models, viewBags, cacheNames, razorTemplateFilePaths, parallel).ToList();
         }
 
         /// <summary>

--- a/src/Core/RazorEngine.Core/Templating/TemplateService.cs
+++ b/src/Core/RazorEngine.Core/Templating/TemplateService.cs
@@ -59,36 +59,26 @@
         #endregion
 
         #region Properties
-        /// <summary>
-        /// Gets the encoded string factory.
-        /// </summary>
         public IEncodedStringFactory EncodedStringFactory { get { return _config.EncodedStringFactory; } }
+
+        public bool IncludeDebugInformation { get; set; }
+
         #endregion
 
         #region Methods
-        /// <summary>
-        /// Adds a namespace that will be imported into the template.
-        /// </summary>
-        /// <param name="ns">The namespace to be imported.</param>
         public void AddNamespace(string ns)
         {
             _config.Namespaces.Add(ns);
         }
 
-        /// <summary>
-        /// Compiles the specified template.
-        /// </summary>
-        /// <param name="razorTemplate">The string template.</param>
-        /// <param name="modelType">The model type.</param>
-        /// <param name="cacheName">The name of the template type in the cache.</param>
-        public void Compile(string razorTemplate, Type modelType, string cacheName)
+        public void Compile(string razorTemplate, Type modelType, string cacheName, string razorTemplateFilePath = null)
         {
             Contract.Requires(razorTemplate != null);
             Contract.Requires(cacheName != null);
 
             int hashCode = razorTemplate.GetHashCode();
 
-            Type type = CreateTemplateType(razorTemplate, modelType);
+            Type type = CreateTemplateType(razorTemplate, modelType, razorTemplateFilePath);
             var item = new CachedTemplateItem(hashCode, type);
 
             _cache.AddOrUpdate(cacheName, item, (n, i) => item);
@@ -105,26 +95,13 @@
             return new InstanceContext(_loader, templateType);
         }
 
-        /// <summary>
-        /// Creates an instance of <see cref="ITemplate"/> from the specified string template.
-        /// </summary>
-        /// <param name="razorTemplate">
-        /// The string template.
-        /// If templateType is not NULL, this parameter may be NULL (unused).
-        /// </param>
-        /// <param name="templateType">
-        /// The template type or NULL if the template type should be dynamically created.
-        /// If razorTemplate is not NULL, this parameter may be NULL (unused).
-        /// </param>
-        /// <param name="model">The model instance or NULL if no model exists.</param>
-        /// <returns>An instance of <see cref="ITemplate"/>.</returns>
         [Pure]
-        public virtual ITemplate CreateTemplate(string razorTemplate, Type templateType, object model)
+        public virtual ITemplate CreateTemplate(string razorTemplate, Type templateType, object model, string razorTemplateFilePath = null)
         {
             if (templateType == null)
             {
                 Type modelType = (model == null) ? typeof(object) : model.GetType();
-                templateType = CreateTemplateType(razorTemplate, modelType);
+                templateType = CreateTemplateType(razorTemplate, modelType, razorTemplateFilePath);
             }
 
             var context = CreateInstanceContext(templateType);
@@ -136,27 +113,8 @@
             return instance;
         }
 
-        /// <summary>
-        /// Creates a set of templates from the specified string templates and models.
-        /// </summary>
-        /// <param name="razorTemplates">
-        /// The set of templates to create or NULL if all template types are already created (see templateTypes).
-        /// If this parameter is NULL, the the templateTypes parameter may not be NULL. 
-        /// Individual elements in this set may be NULL if the corresponding templateTypes[i] is not NULL (precompiled template).
-        /// </param>
-        /// <param name="models">
-        /// The set of models or NULL if no models exist for all templates.
-        /// Individual elements in this set may be NULL if no model exists for a specific template.
-        /// </param>
-        /// <param name="templateTypes">
-        /// The set of template types or NULL to dynamically create template types for each template.
-        /// If this parameter is NULL, the the razorTemplates parameter may not be NULL. 
-        /// Individual elements in this set may be NULL to dynamically create the template if the corresponding razorTemplates[i] is not NULL (dynamically compile template).
-        /// </param>
-        /// <param name="parallel">Flag to determine whether to create templates in parallel.</param>
-        /// <returns>The enumerable set of template instances.</returns>
         [Pure]
-        public virtual IEnumerable<ITemplate> CreateTemplates(IEnumerable<string> razorTemplates, IEnumerable<Type> templateTypes, IEnumerable<object> models, bool parallel = false)
+        public virtual IEnumerable<ITemplate> CreateTemplates(IEnumerable<string> razorTemplates, IEnumerable<Type> templateTypes, IEnumerable<object> models, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false)
         {
             if ((razorTemplates == null) && (templateTypes == null))
                 throw new ArgumentException("The razorTemplates and templateTypes parameters may not both be null.");
@@ -164,6 +122,7 @@
             List<string> razorTemplateList = (razorTemplates == null) ? null : razorTemplates.ToList();
             List<object> modelList = (models == null) ? null : models.ToList();
             List<Type> templateTypeList = (templateTypes == null) ? null : templateTypes.ToList();
+            List<string> razorTemplateFilePathList = (razorTemplateFilePaths == null) ? null : razorTemplateFilePaths.ToList();
 
             int templateCount = (razorTemplateList != null) ? razorTemplateList.Count() : templateTypeList.Count();
 
@@ -175,6 +134,9 @@
 
             if ((modelList != null) && (modelList.Count != templateCount))
                 throw new ArgumentException("Expected the same number of models as the number of templates to be processed.");
+
+            if ((razorTemplateFilePathList != null) && (razorTemplateFilePathList.Count != templateCount))
+                throw new ArgumentException("Expected the same number of template filepath as the number of templates to be processed.");
 
             if ((razorTemplateList != null) && (templateTypeList != null))
             {
@@ -206,41 +168,44 @@
                         .Select((rt, i) => CreateTemplate(
                             rt,
                             (templateTypeList == null) ? null : templateTypeList[i],
-                            (modelList == null) ? null : modelList[i]));
+                            (modelList == null) ? null : modelList[i],
+                            (razorTemplateFilePathList == null) ? null : razorTemplateFilePathList[i]
+                            ));
                 else
                     return GetParallelQueryPlan<Type>()
                         .CreateQuery(templateTypes)
                         .Select((tt, i) => CreateTemplate(
                             (razorTemplateList == null) ? null : razorTemplateList[i],
                             tt,
-                            (modelList == null) ? null : modelList[i]));
+                            (modelList == null) ? null : modelList[i],
+                            (razorTemplateFilePathList == null) ? null : razorTemplateFilePathList[i]
+                            ));
             }
 
             if (razorTemplateList != null)
                 return razorTemplates.Select((rt, i) => CreateTemplate(
                     rt,
                     (templateTypeList == null) ? null : templateTypeList[i],
-                    (modelList == null) ? null : modelList[i]));
+                    (modelList == null) ? null : modelList[i],
+                    (razorTemplateFilePathList == null) ? null : razorTemplateFilePathList[i]
+                    ));
             else
                 return templateTypeList.Select((tt, i) => CreateTemplate(
                     (razorTemplateList == null) ? null : razorTemplateList[i],
                     tt,
-                    (modelList == null) ? null : modelList[i]));
+                    (modelList == null) ? null : modelList[i],
+                    (razorTemplateFilePathList == null) ? null : razorTemplateFilePathList[i]));
         }
 
-        /// <summary>
-        /// Creates a <see cref="Type"/> that can be used to instantiate an instance of a template.
-        /// </summary>
-        /// <param name="razorTemplate">The string template.</param>
-        /// <param name="modelType">The model type or NULL if no model exists.</param>
-        /// <returns>An instance of <see cref="Type"/>.</returns>
         [Pure]
-        public virtual Type CreateTemplateType(string razorTemplate, Type modelType)
+        public virtual Type CreateTemplateType(string razorTemplate, Type modelType, string razorTemplateFilePath = null)
         {
             var context = new TypeContext
                               {
                                   ModelType = (modelType == null) ? typeof(object) : modelType,
                                   TemplateContent = razorTemplate,
+                                  TemplateFileName = razorTemplateFilePath,
+                                  IncludeDebugInformation = IncludeDebugInformation,
                                   TemplateType = (_config.BaseTemplateType) ?? typeof(TemplateBase<>)
                               };
 
@@ -260,31 +225,26 @@
             return result.Item1;
         }
 
-        /// <summary>
-        /// Creates a set of template types from the specfied string templates.
-        /// </summary>
-        /// <param name="razorTemplates">The set of templates to create <see cref="Type"/> instances for.</param>
-        /// <param name="modelTypes">
-        /// The set of model types or NULL if no models exist for all templates.
-        /// Individual elements in this set may be NULL if no model exists for a specific template.
-        /// </param>
-        /// <param name="parallel">Flag to determine whether to create template types in parallel.</param>
-        /// <returns>The set of <see cref="Type"/> instances.</returns>
         [Pure]
-        public virtual IEnumerable<Type> CreateTemplateTypes(IEnumerable<string> razorTemplates, IEnumerable<Type> modelTypes, bool parallel = false)
+        public virtual IEnumerable<Type> CreateTemplateTypes(IEnumerable<string> razorTemplates, IEnumerable<Type> modelTypes, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false)
         {
             Contract.Requires(razorTemplates != null);
 
             List<Type> modelTypeList = (modelTypes == null) ? null : modelTypes.ToList();
+            List<string> razorTemplateFileList = (razorTemplateFilePaths == null)
+                ? null
+                : razorTemplateFilePaths.ToList();
 
             if (parallel)
                 return GetParallelQueryPlan<string>()
                     .CreateQuery(razorTemplates)
                     .Select((t, i) => CreateTemplateType(t,
-                        (modelTypeList == null) ? null : modelTypeList[i]));
+                        (modelTypeList == null) ? null : modelTypeList[i],
+                        (razorTemplateFileList == null) ? null : razorTemplateFileList[i]));
 
             return razorTemplates.Select((t, i) => CreateTemplateType(t,
-                (modelTypeList == null) ? null : modelTypeList[i]));
+                (modelTypeList == null) ? null : modelTypeList[i],
+                (razorTemplateFileList == null) ? null : razorTemplateFileList[i]));
         }
 
         /// <summary>
@@ -339,29 +299,12 @@
             return new DefaultParallelQueryPlan<T>();
         }
 
-        /// <summary>
-        /// Gets an instance of the template using the cached compiled type, or compiles the template type
-        /// if it does not exist in the cache.
-        /// </summary>
-        /// <param name="razorTemplate">The string template.</param>
-        /// <param name="model">The model instance or NULL if there is no model for this template.</param>
-        /// <param name="cacheName">The name of the template type in the cache.</param>
-        /// <returns>An instance of <see cref="ITemplate{T}"/>.</returns>
-        public virtual ITemplate GetTemplate(string razorTemplate, object model, string cacheName)
+        public virtual ITemplate GetTemplate(string razorTemplate, object model, string cacheName, string razorTemplateFilePath = null)
         {
-            return this.GetTemplate<object>(razorTemplate, model, cacheName);
+            return this.GetTemplate<object>(razorTemplate, model, cacheName, razorTemplateFilePath);
         }
 
-        /// <summary>
-        /// Gets an instance of the template using the cached compiled type, or compiles the template type
-        /// if it does not exist in the cache.
-        /// </summary>
-        /// <typeparam name="T">Type of the model</typeparam>
-        /// <param name="razorTemplate">The string template.</param>
-        /// <param name="model">The model instance or NULL if there is no model for this template.</param>
-        /// <param name="cacheName">The name of the template type in the cache.</param>
-        /// <returns>An instance of <see cref="ITemplate{T}"/>.</returns>
-        private ITemplate GetTemplate<T>(string razorTemplate, object model, string cacheName)
+        private ITemplate GetTemplate<T>(string razorTemplate, object model, string cacheName, string razorTemplateFilePath = null)
         {
             if (razorTemplate == null)
                 throw new ArgumentNullException("razorTemplate");
@@ -371,29 +314,17 @@
             CachedTemplateItem item;
             if (!(_cache.TryGetValue(cacheName, out item) && item.CachedHashCode == hashCode))
             {
-                Type type = CreateTemplateType(razorTemplate, (model == null) ? typeof(T) : model.GetType());
+                Type type = CreateTemplateType(razorTemplate, (model == null) ? typeof(T) : model.GetType(), razorTemplateFilePath);
                 item = new CachedTemplateItem(hashCode, type);
 
                 _cache.AddOrUpdate(cacheName, item, (n, i) => item);
             }
 
-            var instance = CreateTemplate(null, item.TemplateType, model);
+            var instance = CreateTemplate(null, item.TemplateType, model, razorTemplateFilePath);
             return instance;
         }
 
-        /// <summary>
-        /// Gets the set of template instances for the specified string templates. Cached templates will be considered
-        /// and if they do not exist, new types will be created and instantiated.
-        /// </summary>
-        /// <param name="razorTemplates">The set of templates to create.</param>
-        /// <param name="models">
-        /// The set of models or NULL if no models exist for all templates.
-        /// Individual elements in this set may be NULL if no model exists for a specific template.
-        /// </param>
-        /// <param name="cacheNames">The set of cache names.</param>
-        /// <param name="parallel">Flag to determine whether to get the templates in parallel.</param>
-        /// <returns>The set of <see cref="ITemplate"/> instances.</returns>
-        public virtual IEnumerable<ITemplate> GetTemplates(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<string> cacheNames, bool parallel = false)
+        public virtual IEnumerable<ITemplate> GetTemplates(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<string> cacheNames, IEnumerable<string> razorTemplateFilePaths = null, bool parallel = false)
         {
             Contract.Requires(razorTemplates != null);
             Contract.Requires(cacheNames != null);
@@ -401,8 +332,12 @@
                               "Expected same number of models as string templates to be processed.");
             Contract.Requires(razorTemplates.Count() == cacheNames.Count(),
                               "Expected same number of cache names as string templates to be processed.");
+            Contract.Requires(razorTemplates.Count() == razorTemplateFilePaths.Count(),
+                              "Expected same number of tempate file paths as string templates to be processed.");
 
             var modelList = (models == null) ? null : models.ToList();
+            var razorTemplateFilePathList = (razorTemplateFilePaths == null) ? null : razorTemplateFilePaths.ToList();
+
             var cacheNameList = cacheNames.ToList();
 
             if (parallel)
@@ -410,76 +345,44 @@
                     .CreateQuery(razorTemplates)
                     .Select((t, i) => GetTemplate(t, 
                         (modelList == null) ? null : modelList[i],
-                        cacheNameList[i]));
+                        cacheNameList[i],
+                        (razorTemplateFilePathList == null) ? null : razorTemplateFilePathList[i]));
 
             return razorTemplates.Select((t, i) => GetTemplate(t, 
                 (modelList == null) ? null : modelList[i],
-                cacheNameList[i]));
+                cacheNameList[i],
+                (razorTemplateFilePathList == null) ? null : razorTemplateFilePathList[i]));
         }
 
 
-        /// <summary>
-        /// Parses and returns the result of the specified string template.
-        /// </summary>
-        /// <param name="razorTemplate">The string template.</param>
-        /// <param name="model">The model instance or NULL if no model exists.</param>
-        /// <param name="viewBag">The ViewBag contents or NULL for an initially empty ViewBag.</param>
-        /// <param name="cacheName">The name of the template type in the cache or NULL if no caching is desired.</param>
-        /// <returns>The string result of the template.</returns>
         [Pure]
-        public virtual string Parse(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName)
+        public virtual string Parse(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName, string razorTemplateFilePath = null)
         {
             ITemplate instance;
             
             if (cacheName == null)
-                instance = CreateTemplate(razorTemplate, null, model);
+                instance = CreateTemplate(razorTemplate, null, model, razorTemplateFilePath);
             else
-                instance = GetTemplate(razorTemplate, model, cacheName);
+                instance = GetTemplate(razorTemplate, model, cacheName, razorTemplateFilePath);
 
             return Run(instance, viewBag);
         }
 
 
-        /// <summary>
-        /// Parses and returns the result of the specified string template.
-        /// </summary>
-        /// <param name="razorTemplate">The string template.</param>
-        /// <param name="model">The model instance or NULL if no model exists.</param>
-        /// <param name="viewBag">The ViewBag contents or NULL for an initially empty ViewBag.</param>
-        /// <param name="cacheName">The name of the template type in the cache or NULL if no caching is desired.</param>
-        /// <returns>The string result of the template.</returns>
         [Pure]
-        public virtual string Parse<T>(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName)
+        public virtual string Parse<T>(string razorTemplate, object model, DynamicViewBag viewBag, string cacheName, string razorTemplateFilePath = null)
         {
             ITemplate instance;
 
             if (cacheName == null)
-                instance = CreateTemplate(razorTemplate, typeof(T), model);
+                instance = CreateTemplate(razorTemplate, typeof(T), model, razorTemplateFilePath);
             else
-                instance = GetTemplate<T>(razorTemplate, model, cacheName);
+                instance = GetTemplate<T>(razorTemplate, model, cacheName, razorTemplateFilePath);
 
             return Run(instance, viewBag);
         }
 
-        /// <summary>
-        /// Parses the specified set of templates.
-        /// </summary>
-        /// <param name="razorTemplates">The set of string templates to parse.</param>
-        /// <param name="models">
-        /// The set of models or NULL if no models exist for all templates.
-        /// Individual elements in this set may be NULL if no model exists for a specific template.
-        /// </param>
-        /// <param name="viewBags">
-        /// The set of initial ViewBag contents or NULL for an initially empty ViewBag for all templates.
-        /// Individual elements in this set may be NULL if an initially empty ViewBag is desired for a specific template.
-        /// </param>
-        /// <param name="cacheNames">
-        /// The set of cache names or NULL if no caching is desired for all templates.
-        /// Individual elements in this set may be NULL if caching is not desired for specific template.
-        /// </param>
-        /// <param name="parallel">Flag to determine whether parsing in parallel.</param>
-        /// <returns>The set of parsed template results.</returns>
-        public virtual IEnumerable<string> ParseMany(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<DynamicViewBag> viewBags, IEnumerable<string> cacheNames, bool parallel)
+        public virtual IEnumerable<string> ParseMany(IEnumerable<string> razorTemplates, IEnumerable<object> models, IEnumerable<DynamicViewBag> viewBags, IEnumerable<string> cacheNames, IEnumerable<string> razorTemplateFilePaths, bool parallel)
         {
             if (razorTemplates == null)
                 throw new ArgumentException("Expected at least one entry in razorTemplates collection.");
@@ -493,9 +396,13 @@
             if ((cacheNames != null) && (razorTemplates.Count() != cacheNames.Count()))
                 throw new ArgumentException("Expected same number of cacheNames as string templates to be processed.");
 
+            if ((razorTemplateFilePaths != null) && (razorTemplates.Count() != razorTemplateFilePaths.Count()))
+                throw new ArgumentException("Expected same number of template file paths as string templates to be processed.");
+
             var modelList = (models == null) ? null : models.ToList();
             var viewBagList = (viewBags == null) ? null : viewBags.ToList();
             var cacheNameList = (cacheNames == null) ? null : cacheNames.ToList();
+            var razorTemplateFilePathList = (razorTemplateFilePaths == null) ? null : razorTemplateFilePaths.ToList();
 
             //
             //  :Matt:
@@ -518,31 +425,23 @@
                     .Select((t, i) => Parse(t,
                         (modelList == null) ? null : modelList[i],
                         (viewBagList == null) ? null : viewBagList[i],
-                        (cacheNameList == null) ? null : cacheNameList[i]))
+                        (cacheNameList == null) ? null : cacheNameList[i],
+                        (razorTemplateFilePathList == null) ? null : razorTemplateFilePathList[i]))
                     .ToArray();
             }
             return razorTemplates.Select((t, i) => Parse(t,
                         (modelList == null) ? null : modelList[i],
                         (viewBagList == null) ? null : viewBagList[i],
-                        (cacheNameList == null) ? null : cacheNameList[i]))
+                        (cacheNameList == null) ? null : cacheNameList[i],
+                        (razorTemplateFilePathList == null) ? null : razorTemplateFilePathList[i]))
                     .ToArray();
         }
 
-        /// <summary>
-        /// Returns whether or not a template by the specified name has been created already.
-        /// </summary>
-        /// <param name="cacheName">The name of the template type in cache.</param>
-        /// <returns>Whether or not the template has been created.</returns>
         public bool HasTemplate(string cacheName)
         {
             return _cache.ContainsKey(cacheName);
         }
 
-        /// <summary>
-        /// Remove a template by the specified name from the cache.
-        /// </summary>
-        /// <param name="cacheName">The name of the template type in cache.</param>
-        /// <returns>Whether or not the template has been removed.</returns>
         public bool RemoveTemplate(string cacheName)
         {
             CachedTemplateItem item;
@@ -550,36 +449,23 @@
         }
 
 
-        /// <summary>
-        /// Resolves the template with the specified name.
-        /// </summary>
-        /// <param name="cacheName">The name of the template type in cache.</param>
-        /// <param name="model">The model or NULL if there is no model for the template.</param>
-        /// <returns>The resolved template.</returns>
         public ITemplate Resolve(string cacheName, object model)
         {
             CachedTemplateItem cachedItem;
             ITemplate instance = null;
             if (_cache.TryGetValue(cacheName, out cachedItem))
-                instance = CreateTemplate(null, cachedItem.TemplateType, model);
+                instance = CreateTemplate(null, cachedItem.TemplateType, model, null);
 
             if (instance == null && _config.Resolver != null)
             {
                 string template = _config.Resolver.Resolve(cacheName);
                 if (!string.IsNullOrWhiteSpace(template))
-                    instance = GetTemplate(template, model, cacheName);
+                    instance = GetTemplate(template, model, cacheName, null);
             }
 
             return instance;
         }
 
-        /// <summary>
-        /// Runs the template with the specified cacheName.
-        /// </summary>
-        /// <param name="cacheName">The name of the template in cache.  The template must be in cache.</param>
-        /// <param name="model">The model for the template or NULL if there is no model.</param>
-        /// <param name="viewBag">The initial ViewBag contents NULL for an empty ViewBag.</param>
-        /// <returns>The string result of the template.</returns>
         public string Run(string cacheName, object model, DynamicViewBag viewBag)
         {
             if (string.IsNullOrWhiteSpace(cacheName))
@@ -589,17 +475,11 @@
             if (!(_cache.TryGetValue(cacheName, out item)))
                 throw new InvalidOperationException("No template exists with name '" + cacheName + "'");
 
-            ITemplate instance = CreateTemplate(null, item.TemplateType, model);
+            ITemplate instance = CreateTemplate(null, item.TemplateType, model, null);
 
             return Run(instance, viewBag);
         }
 
-        /// <summary>
-        /// Runs the specified template and returns the result.
-        /// </summary>
-        /// <param name="template">The template to run.</param>
-        /// <param name="viewBag">The ViewBag contents or NULL for an initially empty ViewBag.</param>
-        /// <returns>The string result of the template.</returns>
         public string Run(ITemplate template, DynamicViewBag viewBag)
         {
             if (template == null)

--- a/src/Core/Tests/RazorEngine.Core.Tests/IsolatedTemplateServiceTestFixture.cs
+++ b/src/Core/Tests/RazorEngine.Core.Tests/IsolatedTemplateServiceTestFixture.cs
@@ -241,7 +241,7 @@
                 const string template = "<h1>Hello World</h1>";
                 var templates = Enumerable.Repeat(template, 10).ToArray();
 
-                var results = service.ParseMany(templates, null, null, null, false);
+                var results = service.ParseMany(templates, null, null, null, null, false);
 
                 Assert.That(templates.SequenceEqual(results), "Rendered templates do not match expected.");
             }
@@ -258,7 +258,7 @@
                 const string template = "<h1>Hello World</h1>";
                 var templates = Enumerable.Repeat(template, 10).ToArray();
 
-                var results = service.ParseMany(templates, null, null, null, true);
+                var results = service.ParseMany(templates, null, null, null, null, true);
 
                 Assert.That(templates.SequenceEqual(results), "Rendered templates do not match expected.");
             }
@@ -279,7 +279,7 @@
                 var templates = Enumerable.Repeat(template, maxTemplates).ToArray();
                 var models = Enumerable.Range(1, maxTemplates).Select(i => new Person { Age = i }).ToArray();
 
-                var results = service.ParseMany(templates, models, null, null, false);
+                var results = service.ParseMany(templates, models, null, null, null, false);
                 Assert.That(expected.SequenceEqual(results), "Parsed templates do not match expected results.");
             }
         }
@@ -299,7 +299,7 @@
                 var templates = Enumerable.Repeat(template, maxTemplates).ToArray();
                 var models = Enumerable.Range(1, maxTemplates).Select(i => new Person { Age = i }).ToArray();
 
-                var results = service.ParseMany(templates, models, null, null, true);
+                var results = service.ParseMany(templates, models, null, null, null, true);
                 Assert.That(expected.SequenceEqual(results), "Parsed templates do not match expected results.");
             }
         }

--- a/src/Core/Tests/RazorEngine.Core.Tests/Issues/Release_3_0_TestFixture.cs
+++ b/src/Core/Tests/RazorEngine.Core.Tests/Issues/Release_3_0_TestFixture.cs
@@ -286,7 +286,7 @@
                 // Success case
                 razorTemplates = new string[] { "Template1", "Template2", "Template3" };
                 templateTypes = new Type[] { null, null, null };
-                IEnumerable<ITemplate> instances = service.CreateTemplates(razorTemplates, templateTypes, null, false);
+                IEnumerable<ITemplate> instances = service.CreateTemplates(razorTemplates, templateTypes, null, null, false);
 
                 index = 0;
                 foreach (ITemplate instance in instances)
@@ -300,7 +300,7 @@
                 // No razorTemplates or templateTypes provided
                 Assert.Throws<ArgumentException>(() =>
                 {
-                    service.CreateTemplates(null, null, null, false);
+                    service.CreateTemplates(null, null, null, null, false);
                 });
 
                 // Unbalanced razorTemplates/templateTypes (templateTypes to small)
@@ -308,7 +308,7 @@
                 {
                     razorTemplates = new string[] { "Template1", "Template2", "Template3" };
                     templateTypes = new Type[] { null, null };
-                    service.CreateTemplates(razorTemplates, templateTypes, null, false);
+                    service.CreateTemplates(razorTemplates, templateTypes, null, null, false);
                 });
 
                 // Unbalanced razorTemplates/templateTypes (templateTypes too large)
@@ -316,7 +316,7 @@
                 {
                     razorTemplates = new string[] { "Template1", "Template2", "Template3" };
                     templateTypes = new Type[] { null, null, null, null };
-                    service.CreateTemplates(razorTemplates, templateTypes, null, false);
+                    service.CreateTemplates(razorTemplates, templateTypes, null, null, false);
                 });
 
                 // Unbalanced razorTemplates/templateTypes (razorTemplates and templateTypes are NULL)
@@ -324,7 +324,7 @@
                 {
                     razorTemplates = new string[] { "Template1", "Template2", null };
                     templateTypes = new Type[] { null, null, null };
-                    service.CreateTemplates(razorTemplates, templateTypes, null, false);
+                    service.CreateTemplates(razorTemplates, templateTypes, null, null, false);
                 });
             }
         }

--- a/src/Core/Tests/RazorEngine.Core.Tests/RazorEngine.Core.Tests.csproj
+++ b/src/Core/Tests/RazorEngine.Core.Tests/RazorEngine.Core.Tests.csproj
@@ -87,6 +87,9 @@
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="RazorEngine.snk" />
+    <Content Include="TemplateServiceDebug.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\RazorEngine.Core\RazorEngine.Core.csproj">

--- a/src/Core/Tests/RazorEngine.Core.Tests/TemplateServiceDebug.cshtml
+++ b/src/Core/Tests/RazorEngine.Core.Tests/TemplateServiceDebug.cshtml
@@ -1,0 +1,16 @@
+﻿@*
+This is to demonstrate debugging on a cshtml loaded from the disk.
+Set a breakpoint inside this file and debug the TemplateServiceTestFixture.TemplateService_CanDebugTemplateLoadedFromDisk
+*@
+@helper TryToDebug()
+{
+    if (System.Diagnostics.Debugger.IsAttached)
+    {
+        <p>Debugger is attached</p>
+    }
+    else
+    {
+        <p>Debugger is not attached</p>
+    }
+}
+@TryToDebug()

--- a/src/Core/Tests/RazorEngine.Core.Tests/TemplateServiceTestFixture.cs
+++ b/src/Core/Tests/RazorEngine.Core.Tests/TemplateServiceTestFixture.cs
@@ -1,4 +1,6 @@
-﻿using RazorEngine.Tests.TestTypes.BaseTypes;
+﻿using System;
+using System.IO;
+using RazorEngine.Tests.TestTypes.BaseTypes;
 
 namespace RazorEngine.Tests
 {
@@ -198,7 +200,7 @@ namespace RazorEngine.Tests
                 const string template = "<h1>Hello World</h1>";
                 var templates = Enumerable.Repeat(template, 10);
 
-                var results = service.ParseMany(templates, null, null, null, false);
+                var results = service.ParseMany(templates, null, null, null, null, false);
 
                 Assert.That(templates.SequenceEqual(results), "Rendered templates do not match expected.");
             }
@@ -215,7 +217,7 @@ namespace RazorEngine.Tests
                 const string template = "<h1>Hello World</h1>";
                 var templates = Enumerable.Repeat(template, 10);
 
-                var results = service.ParseMany(templates, null, null, null, true);
+                var results = service.ParseMany(templates, null, null, null, null, true);
 
                 Assert.That(templates.SequenceEqual(results), "Rendered templates do not match expected."); 
             }
@@ -236,7 +238,7 @@ namespace RazorEngine.Tests
                 var templates = Enumerable.Repeat(template, maxTemplates);
                 var models = Enumerable.Range(1, maxTemplates).Select(i => new Person { Age = i });
 
-                var results = service.ParseMany(templates, models, null, null, false);
+                var results = service.ParseMany(templates, models, null, null, null, false);
                 Assert.That(expected.SequenceEqual(results), "Parsed templates do not match expected results.");
             }
         }
@@ -256,7 +258,7 @@ namespace RazorEngine.Tests
                 var templates = Enumerable.Repeat(template, maxTemplates);
                 var models = Enumerable.Range(1, maxTemplates).Select(i => new Person { Age = i });
 
-                var results = service.ParseMany(templates, models, null, null, true);
+                var results = service.ParseMany(templates, models, null, null, null, true);
                 Assert.That(expected.SequenceEqual(results), "Parsed templates do not match expected results.");
             }
         }
@@ -535,6 +537,31 @@ namespace RazorEngine.Tests
                 Assert.That(result == expected, "Result does not match expected: " + result);
             }
         }
+
+        [Test]
+        public void TemplateService_CanDebugTemplateLoadedFromDisk()
+        {
+            var debuggerIsAttached = System.Diagnostics.Debugger.IsAttached;
+
+            using (var service = new TemplateService())
+            {
+                // Include debug information in order to support debugging of cshtml
+                service.IncludeDebugInformation = true;
+
+                // Place a breakpoint inside TemplateServiceDebug.cshtml in order to check that debugging is working
+                string templateFilePath = Path.Combine(Environment.CurrentDirectory, "TemplateServiceDebug.cshtml");
+                string template = File.ReadAllText(templateFilePath);
+                string expected =
+                    debuggerIsAttached
+                        ? "<p>Debugger is attached</p>"
+                        : "<p>Debugger is not attached</p>";
+
+                string result = service.Parse(template, null, null, null, templateFilePath).Trim();
+
+                Assert.That(result == expected, "Result does not match expected: " + result);
+            }
+        }
+
         #endregion
     }
 }

--- a/src/Hosts/RazorEngine.Hosts.Console/Program.cs
+++ b/src/Hosts/RazorEngine.Hosts.Console/Program.cs
@@ -19,7 +19,7 @@
                 var templates = Enumerable.Repeat(template, 10).ToList();
                 var models = Enumerable.Range(1, 10).Select(i => new Person { Age = i });
 
-                var results = service.ParseMany(templates, models, null, null, true).ToList();
+                var results = service.ParseMany(templates, models, null, null, null, true).ToList();
 
                 for (int i = 0; i < 10; i++)
                 {


### PR DESCRIPTION
Hi there!

This pull request is a backport of an old patch done on a previous version of RazorEngine that was never integrated into the trunk (See https://razorengine.codeplex.com/SourceControl/list/patches  9279 and 9277)

It is basically adding support for debugging templates within Visual Studio that were loaded from the disk.

You can check and test this feature by debugging the test : `TemplateServiceTestFixture.TemplateService_CanDebugTemplateLoadedFromDisk` and putting a breakpoint into the file `TemplateServiceDebug.cshtml` (on the line `if (System.Diagnostics.Debugger.IsAttached)`. Breakpoints can only be set on valid C# code line).

It is modifying lots of different interfaces (as we have to pass a templateFilePath along the templateContent), but interfaces and main Razor class contracts were kept compatible by setting default to null for this new parameter.
