### PR TITLE
Add define to compiler options

### DIFF
--- a/src/Core/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
+++ b/src/Core/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
@@ -58,7 +58,7 @@
                 GenerateInMemory = true,
                 GenerateExecutable = false,
                 IncludeDebugInformation = false,
-                CompilerOptions = "/target:library /optimize"
+                CompilerOptions = "/target:library /optimize /define:RAZORENGINE"
             };
 
             var assemblies = CompilerServicesUtility


### PR DESCRIPTION
Add RAZORENGINE define to compiler options to allow conditional compiling on templates. It is useful when using the same template with MVC Razor and RazorEngine.
