### PR TITLE
Add optional parameter to DynamicViewBag constructor

### DIFF
--- a/src/Core/RazorEngine.Core/Templating/DynamicViewBag.cs
+++ b/src/Core/RazorEngine.Core/Templating/DynamicViewBag.cs
@@ -11,7 +11,14 @@
     public class DynamicViewBag : DynamicObject
     {
         #region Fields
-        private readonly IDictionary<string, object> _dict = new Dictionary<string, object>();
+        private readonly IDictionary<string, object> _dict;
+        #endregion
+
+        #region Constructors
+        public DynamicViewBag(IDictionary<string, object> dictionary = null)
+        {
+            _dict = dictionary ?? new Dictionary<string, object>();
+        }
         #endregion
 
         #region DynamicObject Overrides


### PR DESCRIPTION
Adding an optional `IDictionary<string, object>` parameter allows the
`DynamicViewBag` to wrap a `ViewDataDictionary` for use in applications
where a more MVC-style `TemplateBase` is wanted.
