### PR TITLE
Read global configuration values from App.config / Web.config by default

### DIFF
--- a/src/Core/RazorEngine.Core/Configuration/TemplateServiceConfiguration.cs
+++ b/src/Core/RazorEngine.Core/Configuration/TemplateServiceConfiguration.cs
@@ -1,4 +1,7 @@
-﻿namespace RazorEngine.Configuration
+﻿using System.Linq;
+using RazorEngine.Configuration.Xml;
+
+namespace RazorEngine.Configuration
 {
     using System;
     using System.Collections.Generic;
@@ -19,10 +22,15 @@
         /// </summary>
         public TemplateServiceConfiguration()
         {
-            Activator = new DefaultActivator();
-            CompilerServiceFactory = new DefaultCompilerServiceFactory();
-            EncodedStringFactory = new HtmlEncodedStringFactory();
-            CodeInspectors = new List<ICodeInspector>();
+            // Read configuration values from App.config / Web.config
+            // and fallback to appropriate defaults. 
+            var xmlConfig = new XmlTemplateServiceConfiguration();
+
+            Activator = xmlConfig.Activator ?? new DefaultActivator();
+            CompilerServiceFactory = xmlConfig.CompilerServiceFactory ?? new DefaultCompilerServiceFactory();
+            EncodedStringFactory = xmlConfig.EncodedStringFactory ?? new HtmlEncodedStringFactory();
+            CodeInspectors = xmlConfig.CodeInspectors != null ? xmlConfig.CodeInspectors.ToList()  : new List<ICodeInspector>();
+            Language = xmlConfig.Language;
 
             Namespaces = new HashSet<string>
                              {
@@ -31,10 +39,7 @@
                                  "System.Linq"
                              };
 
-            var config = RazorEngineConfigurationSection.GetConfiguration();
-            Language = (config == null)
-                           ? Language.CSharp
-                           : config.DefaultLanguage;
+            Namespaces.UnionWith(xmlConfig.Namespaces);
         }
         #endregion
 


### PR DESCRIPTION
This addresses issue #152 and modifies the behaviour of RazorEngine's configuration system to make closer to what I believe would be the expected behaviour for a .NET library.

 RazorEngine defines the `ITemplateServiceConfiguration` interface for its configuration system and provides two implementations of it: `TemplateServiceConfiguration` and `XmlTemplateServiceConfiguration` (it also provide a third implementation, `FluentTemplateServiceConfiguration`, but that one is not relevant to this issue).

--- **Current behaviour** ---
**TemplateServiceConfiguration:** this is the configuration system used by default by RazorEngine. It reads the default template language from the App.config / Web.config file but ignores every other configuration value specified in the configuration file and uses hardcoded defaults instead.

**XmlTemplateServiceConfiguration:** reads all its configurations values from App.config / Web.config. Configuration values that aren't explicitly specified in the config file are left null, resulting in NullReferenceExceptions later on when these values are used.

--- **New Behaviour** ---
**TemplateServiceConfiguration:** this now reads all the global configuration values from App.config / Web.config and only uses hardcoded defaults for the values that aren't specified in the config file. At the moment, TemplateServiceConfiguration still ignores any template service configuration element. In order to avoid code duplication, `TemplateServiceConfiguration` now uses `XmlTemplateServiceConfiguration` behind the scenes to get the config file values. 

**XmlTemplateServiceConfiguration:** haven't changed its behaviour. I personally think that it could be worth merging `TemplateServiceConfiguration` and `XmlTemplateServiceConfiguration` but that would break backwards compatibility so I've left it as it.

A good compromise I think between making the configuration system behave more as one would expect while still retaining backwards compatibility - existing code using RazorEngine shouldn't be affected by these changes. 
