### PR TITLE
Fail fast and with meaningful message when layout is missing

### DIFF
--- a/src/Core/RazorEngine.Core/Templating/TemplateBase.cs
+++ b/src/Core/RazorEngine.Core/Templating/TemplateBase.cs
@@ -134,6 +134,11 @@ namespace RazorEngine.Templating
                 // Get the layout template.
                 var layout = ResolveLayout(Layout);
 
+                if (layout == null)
+                {
+                    throw new ArgumentException("Template you are trying to run uses layout, but no layout found in cache or by resolver.");
+                }
+
                 // Push the current body instance onto the stack for later execution.
                 var body = new TemplateWriter(tw => tw.Write(builder.ToString()));
                 context.PushBody(body);

--- a/src/Core/Tests/RazorEngine.Core.Tests/TemplateServiceTestFixture.cs
+++ b/src/Core/Tests/RazorEngine.Core.Tests/TemplateServiceTestFixture.cs
@@ -1,4 +1,5 @@
-﻿using RazorEngine.Tests.TestTypes.BaseTypes;
+﻿using System;
+using RazorEngine.Tests.TestTypes.BaseTypes;
 
 namespace RazorEngine.Tests
 {
@@ -533,6 +534,19 @@ namespace RazorEngine.Tests
                 string result = service.Parse(template, model, null, null);
 
                 Assert.That(result == expected, "Result does not match expected: " + result);
+            }
+        }
+
+        /// <summary>
+        /// When template uses layout but that layout is not specified in cache or by resolver, fail with a meaningful exception
+        /// </summary>
+        [Test]
+        public void TemplateBase_ParseWithLayout_WithoutPrecompiling()
+        {
+            using (var service = new TemplateService())
+            {
+                var template = @"@{Layout = ""Layout"";} @section Body {Test}";
+                Assert.Throws<ArgumentException>(() => service.Parse(template, null, null, null));
             }
         }
         #endregion


### PR DESCRIPTION
When someone forgets to precompile or specify the template, RazorEngine
should fail fast and with meaningful exception.

This is related to issue #139
