### PR TITLE
Fixed bug in IsAnonymousType for VB

### DIFF
--- a/src/Core/RazorEngine.Core/Compilation/CompilerServicesUtility.cs
+++ b/src/Core/RazorEngine.Core/Compilation/CompilerServicesUtility.cs
@@ -37,7 +37,8 @@ namespace RazorEngine.Compilation
             return (type.IsClass
                     && type.IsSealed
                     && type.BaseType == typeof(object)
-                    && type.Name.StartsWith("<>", StringComparison.Ordinal)
+                    && (type.Name.StartsWith("<>", StringComparison.Ordinal)
+                        || type.Name.StartsWith("VB$Anonymous", StringComparison.Ordinal))
                     && type.IsDefined(typeof(CompilerGeneratedAttribute), true));
         }
 


### PR DESCRIPTION
VB.NET anonymous types have the prefix "VB$Anonymous" - this change
fixes bug where anon type passed from VB code would fail
