### PR TITLE
WriteTo method bug fix.

### DIFF
--- a/src/Core/RazorEngine.Core/Templating/TemplateBase.cs
+++ b/src/Core/RazorEngine.Core/Templating/TemplateBase.cs
@@ -330,7 +330,7 @@ namespace RazorEngine.Templating
             else
             {
                 encodedString = TemplateService.EncodedStringFactory.CreateEncodedString(value);
-                _context.CurrentWriter.Write(encodedString);
+                writer.Write(encodedString);
             }
         }
 


### PR DESCRIPTION
WriteTo method bug fix. WriteTo method should use TextWriter from paramer rather than from context.
