### PR TITLE
./build Test_40

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -219,16 +219,31 @@ Target "Release" (fun _ ->
 "Clean_single" 
   ==> "CleanAll_single"
 
-// Dependencies
-"Clean" 
+"Clean"
   ==> "RestorePackages"
   ==> "SetVersions" 
+
+"SetVersions"
   ==> "BuildApp_40"
+"SetVersions"
+  ==> "BuildApp_45"
+
+"BuildApp_40"
   ==> "BuildTest_40"
   ==> "Test_40"
-  ==> "BuildApp_45"
+  
+"BuildApp_45"
   ==> "BuildTest_45"
   ==> "Test_45"
+  
+"Test_40"
+  ==> "All"
+"Test_45"
+  ==> "All"
+
+
+// Dependencies
+"Clean" 
   ==> "CopyToRelease"
   ==> "LocalDoc"
   ==> "All"

--- a/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
+++ b/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
@@ -22,7 +22,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>


### PR DESCRIPTION
and
./build Test_45
can now be used to execute only the unit tests for net40 or net45.

Now we can execute the NET45 tests when we select Debug within Visual Studio
