### PR TITLE
Add unittest which passes an inline template into an included template.

### DIFF
--- a/src/test/Test.RazorEngine.Core/TemplateBaseTestFixture.cs
+++ b/src/test/Test.RazorEngine.Core/TemplateBaseTestFixture.cs
@@ -176,6 +176,27 @@
             }
         }
 
+        /// <summary>
+        /// Tests that a template service can pass inline templates into an included template
+        /// and outputs this in the correct order
+        /// </summary>
+        [Test]
+        public void TemplateBase_CanRenderInclude_WithInlineTemplate()
+        {
+            using (var service = new TemplateService())
+            {
+                const string child = "@model RazorEngine.Tests.TestTypes.InlineTemplateModel\n@Model.InlineTemplate(Model)";
+                const string template = "@model RazorEngine.Tests.TestTypes.InlineTemplateModel\n@{ Model.InlineTemplate = @<h1>@ViewBag.Name</h1>; }@Include(\"Child\", Model)";
+                const string expected = "<h1>Matt</h1>";
+
+                dynamic bag = new DynamicViewBag();
+                bag.Name = "Matt";
+
+                service.GetTemplate(child, null, "Child");
+                string result = service.Parse(template, new InlineTemplateModel(), bag, null);
+                Assert.That(result == expected, "Result does not match expected: " + result);
+            }
+        }
         #endregion
     }
 }

--- a/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
+++ b/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
@@ -100,6 +100,7 @@
     <Compile Include="TestTypes\AnimalViewModel.cs" />
     <Compile Include="TestTypes\BaseTypes\NonGenericTemplateBase.cs" />
     <Compile Include="TestTypes\Employee.cs" />
+    <Compile Include="TestTypes\InlineTemplateModel.cs" />
     <Compile Include="TestTypes\Inspectors\ThrowExceptionCodeInspector.cs" />
     <Compile Include="Issues\Release_3_0_TestFixture.cs" />
     <Compile Include="TestTypes\ThreadPoolItem.cs" />

--- a/src/test/Test.RazorEngine.Core/TestTypes/InlineTemplateModel.cs
+++ b/src/test/Test.RazorEngine.Core/TestTypes/InlineTemplateModel.cs
@@ -1,0 +1,10 @@
+﻿namespace RazorEngine.Tests.TestTypes
+{
+    using System;
+    using RazorEngine.Templating;
+
+    public class InlineTemplateModel
+    {
+        public Func<dynamic, TemplateWriter> InlineTemplate { get; set; }
+    }
+}


### PR DESCRIPTION
The TemplateBase.WriteTo used a different writer for IEncodedString than
for other types. In most situations the writer argument contains the same
writer as the _context.CurrentWriter, but not when passing an inline
template into an included template. As a result the
output was in the wrong order. This bug was fixed in
67e2f20a036fa52d04e9fd8228cbbf2fd94e8a8b
