### PR TITLE
Load assemblies from memory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,19 @@ static int Main(string[] args)
 
 Depending on your scenario you probably need to edit it to your needs.
 Note that you need to `Unload` the domain to trigger cleanup.
+
+For the following scenario:
+
+ * Your templates are limited in number.
+ * You fully trust your templates / don't need isolation.
+ * You don't need any kind of debugging support.
+ * Your templates do not change in runtime.
+
+You can use `config.DisableTempFileLocking = true` as well. This will work in any AppDomain (including the default one).
+To remove the RazorEngine warnings you can additionally use `config.CachingProvider = new DefaultCachingProvider(t => {})`.
+
 See also https://github.com/Antaris/RazorEngine/issues/244 for more details.
+
 
 ## More
 

--- a/buildConfig.fsx
+++ b/buildConfig.fsx
@@ -41,9 +41,9 @@ let projectDescription_roslyn = "RazorEngine.Roslyn - Roslyn support for RazorEn
 // !!!!!!!!!!!!!!!!!!!
 // UPDATE RELEASE NOTES AS WELL!
 // !!!!!!!!!!!!!!!!!!!
-let version_razor4 = "4.1.3-beta2"
-let version_roslyn = "3.5.1-beta1"
-let version_roslyn_razor4 = "4.0.1-beta1"
+let version_razor4 = "4.1.4-beta2"
+let version_roslyn = "3.5.2-beta1"
+let version_roslyn_razor4 = "4.0.2-beta1"
 
 // This is set to true when we want to update the roslyn packages via CI as well
 // (otherwise this value doesn't matter). You can always push manually!

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,5 +1,10 @@
 ﻿### 3.6.4 / 4.1.4-beta1
 * Use /nostdlib when we find a mscorlib (improves mono support)
+* Added `DisableTempFileLocking` to load assemblies in memory (to prevent temp file locking), 
+  this is only recommended in a very limited amount of scenarios.
+  Please be aware of the consequences before using it.
+  Please read https://github.com/Antaris/RazorEngine/issues/244 for details.
+  Note that this can introduce memory leaks to your application.
 
 ### 3.6.3 / 4.1.3-beta2
 * Cleanup temporary files when RazorEngine is not used in the default AppDomain

--- a/src/RazorEngine.sln
+++ b/src/RazorEngine.sln
@@ -27,10 +27,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.travis.yml = ..\.travis.yml
 		..\appveyor.yml = ..\appveyor.yml
 		..\buildConfig.fsx = ..\buildConfig.fsx
-		buildConfig.targets = buildConfig.targets
-		buildHelper.targets = buildHelper.targets
 		..\generateDocs.fsx = ..\generateDocs.fsx
-		..\packages.config = ..\packages.config
 		..\readme.md = ..\readme.md
 	EndProjectSection
 EndProject

--- a/src/source/RazorEngine.Core.Roslyn/RoslynCompilerServiceBase.cs
+++ b/src/source/RazorEngine.Core.Roslyn/RoslynCompilerServiceBase.cs
@@ -248,7 +248,17 @@ namespace RazorEngine.Roslyn.CSharp
             }
 
             // load file and return loaded type.
-            var assembly = Assembly.LoadFrom(assemblyFile);
+            Assembly assembly;
+            if (DisableTempFileLocking)
+            {
+                assembly = File.Exists(assemblyPdbFile)
+                    ? Assembly.Load(File.ReadAllBytes(assemblyFile), File.ReadAllBytes(assemblyPdbFile))
+                    : Assembly.Load(File.ReadAllBytes(assemblyFile));
+            }
+            else
+            {
+                assembly = Assembly.LoadFrom(assemblyFile);
+            }
             var type = assembly.GetType(DynamicTemplateNamespace + "." + context.ClassName);
             return Tuple.Create(type, compilationData);
         }

--- a/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
+++ b/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
@@ -112,6 +112,12 @@
         public bool Debug { get; set; }
 
         /// <summary>
+        /// Gets or sets whether the compiler should load assemblies with Assembly.Load(byte[])
+        /// to prevent files from being locked.
+        /// </summary>
+        public bool DisableTempFileLocking { get; set; }
+
+        /// <summary>
         /// Gets the markup parser.
         /// </summary>
         public ParserBaseCreator MarkupParserFactory { [SecurityCritical] get; [SecurityCritical] private set; }

--- a/src/source/RazorEngine.Core/Compilation/CrossAppDomainCleanUp.cs
+++ b/src/source/RazorEngine.Core/Compilation/CrossAppDomainCleanUp.cs
@@ -453,6 +453,7 @@ namespace RazorEngine.Compilation
                     System.Console.Error.WriteLine("RazorEngine: We can't cleanup temp files if you use RazorEngine on the default Appdomain.");
                     System.Console.Error.WriteLine("Create a new AppDomain and use RazorEngine from there.");
                     System.Console.Error.WriteLine("Read the quickstart or https://github.com/Antaris/RazorEngine/issues/244 for details!");
+                    System.Console.Error.WriteLine("You can ignore this and all following 'Please clean ... manually' messages if you are using DisableTempFileLocking, which is not recommended.");
                     writtenLongMessage = true;
                 }
                 if (throwOnDefault)

--- a/src/source/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
+++ b/src/source/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
@@ -258,7 +258,14 @@
             // Make sure we load the assembly from a file and not with
             // Load(byte[]) (or it will be fully trusted!)
             var assemblyPath = compileResult.PathToAssembly;
-            compileResult.CompiledAssembly = Assembly.LoadFile(assemblyPath);
+            if (DisableTempFileLocking)
+            {
+                compileResult.CompiledAssembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            }
+            else
+            {
+                compileResult.CompiledAssembly = Assembly.LoadFile(assemblyPath);
+            }
             var type = compileResult.CompiledAssembly.GetType(DynamicTemplateNamespace + "." + context.ClassName);
             if (type == null)
             {

--- a/src/source/RazorEngine.Core/Compilation/ICompilerService.cs
+++ b/src/source/RazorEngine.Core/Compilation/ICompilerService.cs
@@ -31,6 +31,13 @@
         /// Gets or sets whether the compiler service is operating in debug mode.
         /// </summary>
         bool Debug { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the compiler should load assemblies with Assembly.Load(byte[])
+        /// to prevent files from being locked.
+        /// </summary>
+        bool DisableTempFileLocking { get; set; }
+
         #endregion
 
         #region Methods

--- a/src/source/RazorEngine.Core/Configuration/Fluent/FluentConfigurationBuilder.cs
+++ b/src/source/RazorEngine.Core/Configuration/Fluent/FluentConfigurationBuilder.cs
@@ -238,6 +238,23 @@
         }
 
         /// <summary>
+        /// Loads all dynamic assemblies with Assembly.Load(byte[]).
+        /// This prevents temp files from being locked (which makes it impossible for RazorEngine to delete them).
+        /// At the same time this completely shuts down any sandboxing/security.
+        /// Use this only if you have a limited amount of static templates (no modifications on rumtime), 
+        /// which you fully trust and when a seperate AppDomain is no solution for you!.
+        /// This option will also hurt debugging.
+        /// 
+        /// OK, YOU HAVE BEEN WARNED.
+        /// </summary>
+        /// <returns>The current configuration builder.</returns>
+        public IConfigurationBuilder DisableTempFileLocking()
+        {
+            _config.DisableTempFileLocking = true;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the default activator.
         /// </summary>
         /// <returns>The current configuration builder.</returns>

--- a/src/source/RazorEngine.Core/Configuration/Fluent/FluentTemplateServiceConfiguration.cs
+++ b/src/source/RazorEngine.Core/Configuration/Fluent/FluentTemplateServiceConfiguration.cs
@@ -50,6 +50,21 @@
         }
 
         /// <summary>
+        /// Loads all dynamic assemblies with Assembly.Load(byte[]).
+        /// This prevents temp files from being locked (which makes it impossible for RazorEngine to delete them).
+        /// At the same time this completely shuts down any sandboxing/security.
+        /// Use this only if you have a limited amount of static templates (no modifications on rumtime), 
+        /// which you fully trust and when a seperate AppDomain is no solution for you!.
+        /// This option will also hurt debugging.
+        /// 
+        /// OK, YOU HAVE BEEN WARNED.
+        /// </summary>
+        public bool DisableTempFileLocking
+        {
+            get { return _innerConfig.DisableTempFileLocking; }
+        }
+
+        /// <summary>
         /// Gets the base template type.
         /// </summary>
         public Type BaseTemplateType

--- a/src/source/RazorEngine.Core/Configuration/Fluent/IConfigurationBuilder.cs
+++ b/src/source/RazorEngine.Core/Configuration/Fluent/IConfigurationBuilder.cs
@@ -126,6 +126,19 @@
         IConfigurationBuilder IncludeNamespaces(params string[] namespaces);
 
         /// <summary>
+        /// Loads all dynamic assemblies with Assembly.Load(byte[]).
+        /// This prevents temp files from being locked (which makes it impossible for RazorEngine to delete them).
+        /// At the same time this completely shuts down any sandboxing/security.
+        /// Use this only if you have a limited amount of static templates (no modifications on rumtime), 
+        /// which you fully trust and when a seperate AppDomain is no solution for you!.
+        /// This option will also hurt debugging.
+        /// 
+        /// OK, YOU HAVE BEEN WARNED.
+        /// </summary>
+        /// <returns>The current configuration builder.</returns>
+        IConfigurationBuilder DisableTempFileLocking();
+
+        /// <summary>
         /// Sets the default activator.
         /// </summary>
         /// <returns>The current configuration builder.</returns>

--- a/src/source/RazorEngine.Core/Configuration/ITemplateServiceConfiguration.cs
+++ b/src/source/RazorEngine.Core/Configuration/ITemplateServiceConfiguration.cs
@@ -59,6 +59,18 @@
         bool Debug { get; }
 
         /// <summary>
+        /// Loads all dynamic assemblies with Assembly.Load(byte[]).
+        /// This prevents temp files from being locked (which makes it impossible for RazorEngine to delete them).
+        /// At the same time this completely shuts down any sandboxing/security.
+        /// Use this only if you have a limited amount of static templates (no modifications on rumtime), 
+        /// which you fully trust and when a seperate AppDomain is no solution for you!.
+        /// This option will also hurt debugging.
+        /// 
+        /// OK, YOU HAVE BEEN WARNED.
+        /// </summary>
+        bool DisableTempFileLocking { get; }
+
+        /// <summary>
         /// Gets the encoded string factory.
         /// </summary>
         IEncodedStringFactory EncodedStringFactory { get; }

--- a/src/source/RazorEngine.Core/Configuration/RazorEngineConfigurationSection.cs
+++ b/src/source/RazorEngine.Core/Configuration/RazorEngineConfigurationSection.cs
@@ -12,6 +12,7 @@
         #region Fields
         private const string ActivatorAttribute = "activatorType";
         private const string AllowMissingPropertiesOnDynamicAttribute = "allowMissingPropertiesOnDynamic";
+        private const string DisableTempFileLockingAttribute = "disableTempFileLocking";
         private const string CompilerServiceFactoryAttribute = "compilerServiceFactoryType";
         private const string DefaultLanguageAttribute = "defaultLanguage";
         private const string NamespacesElement = "namespaces";
@@ -40,6 +41,15 @@
         public bool AllowMissingPropertiesOnDynamic
         {
             get { return (bool)this[AllowMissingPropertiesOnDynamicAttribute]; }
+        }
+
+        /// <summary>
+        /// Gets or sets whether to allow missing properties on dynamic models.
+        /// </summary>
+        [ConfigurationProperty(DisableTempFileLockingAttribute, IsRequired = false, DefaultValue = false)]
+        public bool DisableTempFileLocking
+        {
+            get { return (bool)this[DisableTempFileLockingAttribute]; }
         }
 
         /// <summary>

--- a/src/source/RazorEngine.Core/Configuration/TemplateServiceConfiguration.cs
+++ b/src/source/RazorEngine.Core/Configuration/TemplateServiceConfiguration.cs
@@ -77,6 +77,18 @@ namespace RazorEngine.Configuration
         public bool AllowMissingPropertiesOnDynamic { get; set; }
 
         /// <summary>
+        /// Loads all dynamic assemblies with Assembly.Load(byte[]).
+        /// This prevents temp files from being locked (which makes it impossible for RazorEngine to delete them).
+        /// At the same time this completely shuts down any sandboxing/security.
+        /// Use this only if you have a limited amount of static templates (no modifications on rumtime), 
+        /// which you fully trust and when a seperate AppDomain is no solution for you!.
+        /// This option will also hurt debugging.
+        /// 
+        /// OK, YOU HAVE BEEN WARNED.
+        /// </summary>
+        public bool DisableTempFileLocking { get; set; }
+
+        /// <summary>
         /// Gets or sets the base template type.
         /// </summary>
         public Type BaseTemplateType { get; set; }

--- a/src/source/RazorEngine.Core/Configuration/Xml/XmlTemplateServiceConfiguration.cs
+++ b/src/source/RazorEngine.Core/Configuration/Xml/XmlTemplateServiceConfiguration.cs
@@ -50,6 +50,18 @@
         public bool AllowMissingPropertiesOnDynamic { get; private set; }
 
         /// <summary>
+        /// Loads all dynamic assemblies with Assembly.Load(byte[]).
+        /// This prevents temp files from being locked (which makes it impossible for RazorEngine to delete them).
+        /// At the same time this completely shuts down any sandboxing/security.
+        /// Use this only if you have a limited amount of static templates (no modifications on rumtime), 
+        /// which you fully trust and when a seperate AppDomain is no solution for you!.
+        /// This option will also hurt debugging.
+        /// 
+        /// OK, YOU HAVE BEEN WARNED.
+        /// </summary>
+        public bool DisableTempFileLocking { get; private set; }
+
+        /// <summary>
         /// Gets the base template type.
         /// </summary>
         public Type BaseTemplateType { get; private set; }
@@ -183,6 +195,9 @@
         {
             // Set whether we are allowing missing properties on dynamic.
             AllowMissingPropertiesOnDynamic = config.AllowMissingPropertiesOnDynamic;
+
+            // Set whether we load templates with Assembly.Load(byte[]).
+            DisableTempFileLocking = config.DisableTempFileLocking;
 
             // Add the global namespaces.
             AddNamespaces(config.Namespaces);

--- a/src/source/RazorEngine.Core/Templating/IsolatedRazorEngineService.cs
+++ b/src/source/RazorEngine.Core/Templating/IsolatedRazorEngineService.cs
@@ -206,6 +206,11 @@
         {
             configCreator = configCreator ?? new DefaultConfigCreator();
             var config = configCreator.CreateConfiguration();
+            if (config.DisableTempFileLocking)
+            {
+                throw new InvalidOperationException("DisableTempFileLocking is not supported in the context of Isolation, because it will escape any kind of sandbox. Besides that it's not required because RazorEngine will be able to cleanup the tempfiles in this scenario. Just make sure to call AppDomain.Unload when you are done.");
+            }
+
             var isolated = new IsolatedRazorEngineService(configCreator, appDomainFactory);
             return new DynamicWrapperService(isolated, true, config.AllowMissingPropertiesOnDynamic);
         }

--- a/src/source/RazorEngine.Core/Templating/RazorEngineCore.cs
+++ b/src/source/RazorEngine.Core/Templating/RazorEngineCore.cs
@@ -30,7 +30,7 @@ namespace RazorEngine.Templating
         {
             Contract.Requires(config != null);
             Contract.Requires(config.TemplateManager != null);
-
+            
             _config = config;
             _cached = cached;
         }
@@ -108,6 +108,7 @@ namespace RazorEngine.Templating
                 .CompilerServiceFactory
                 .CreateCompilerService(_config.Language);
             service.Debug = _config.Debug;
+            service.DisableTempFileLocking = _config.DisableTempFileLocking;
 #if !RAZOR4
 #pragma warning disable 0618 // Backwards Compat.
             service.CodeInspectors = _config.CodeInspectors ?? Enumerable.Empty<ICodeInspector>();

--- a/src/source/RazorEngine.Core/Templating/RazorEngineService.cs
+++ b/src/source/RazorEngine.Core/Templating/RazorEngineService.cs
@@ -37,6 +37,10 @@ namespace RazorEngine.Templating
         internal RazorEngineService(ITemplateServiceConfiguration config)
         {
             Contract.Requires(config != null);
+            if (config.Debug && config.DisableTempFileLocking)
+            {
+                throw new InvalidOperationException("Debug && DisableTempFileLocking is not supported, you need to disable one of them. When Roslyn has been released and you are seeing this, open an issue as this might be possible now.");
+            }
 
             _config = config;
             //_core = new RazorEngineCore(config, this);

--- a/src/test/Test.RazorEngine.Core/IsolatedRazorEngineServiceTestFixture.cs
+++ b/src/test/Test.RazorEngine.Core/IsolatedRazorEngineServiceTestFixture.cs
@@ -18,6 +18,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Razor;
 #else
 using System.Web.Razor;
+using RazorEngine.Configuration;
 #endif
 
 namespace Test.RazorEngine
@@ -566,5 +567,43 @@ File.WriteAllText(""$file$"", ""BAD DATA"");
                 { }
             });
         }
+
+        /// <summary>
+        /// Test Type.
+        /// </summary>
+        [Serializable]
+        public class InsecureConfigCreator : IsolatedRazorEngineService.IConfigCreator
+        {
+            /// <summary>
+            /// Test Type.
+            /// </summary>
+            public ITemplateServiceConfiguration CreateConfiguration()
+            {
+                var config = new TemplateServiceConfiguration();
+                config.DisableTempFileLocking = true;
+                return config;
+            }
+        }
+
+        /// <summary>
+        /// Tests that we cannot create an insecure sandbox.
+        /// </summary>
+        [Test]
+        public void IsolatedRazorEngineService_WillThrowException_WhenUsingDisableFileLocking()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (var service = IsolatedRazorEngineService.Create(new InsecureConfigCreator(), SandboxCreator))
+                    {
+                        const string template = "<h1>Hello World</h1>";
+                        const string expected = template;
+
+                        string result = service.RunCompile(template, "test");
+
+                        Assert.That(result == expected, "Result does not match expected: " + result);
+                    }
+                });
+        }
+
     }
 }

--- a/src/test/Test.RazorEngine.Core/IsolatedRazorEngineServiceTestFixture.cs
+++ b/src/test/Test.RazorEngine.Core/IsolatedRazorEngineServiceTestFixture.cs
@@ -14,11 +14,11 @@ using System.Security.Permissions;
 using System.Security.Policy;
 using System.Text;
 using System.Threading.Tasks;
+using RazorEngine.Configuration;
 #if RAZOR4
 using Microsoft.AspNet.Razor;
 #else
 using System.Web.Razor;
-using RazorEngine.Configuration;
 #endif
 
 namespace Test.RazorEngine

--- a/src/test/Test.RazorEngine.Core/RazorEngineCleanupTests.cs
+++ b/src/test/Test.RazorEngine.Core/RazorEngineCleanupTests.cs
@@ -102,6 +102,5 @@ namespace Test.RazorEngine
             data.DeleteAll();
             Assert.IsFalse(Directory.Exists(folder));
         }
-
     }
 }

--- a/src/test/Test.RazorEngine.Core/RazorEngineCleanupTests.cs
+++ b/src/test/Test.RazorEngine.Core/RazorEngineCleanupTests.cs
@@ -76,5 +76,32 @@ namespace Test.RazorEngine
             Assert.IsFalse(Directory.Exists(tmp_folder));
         }
 
+        /// <summary>
+        /// Tests whether we can delete tempfiles when DisableTempFileLocking is true.
+        /// </summary>
+        [Test]
+        public void RazorEngineService_TestDisableTempFileLocking()
+        {
+            var cache = new DefaultCachingProvider();
+            var template = "@Model.Property";
+            RazorEngineServiceTestFixture.RunTestHelper(service =>
+            {
+                var model = new { Property = 0 };
+                string result = service.RunCompile(template, "key", null, model);
+                Assert.AreEqual("0", result.Trim());
+            }, config =>
+            {
+                config.CachingProvider = cache;
+                config.DisableTempFileLocking = true;
+            });
+            ICompiledTemplate compiledTemplate;
+            Assert.IsTrue(cache.TryRetrieveTemplate(new NameOnlyTemplateKey("key", ResolveType.Global, null), null, out compiledTemplate));
+            var data = compiledTemplate.CompilationData;
+            var folder = data.TmpFolder;
+            Assert.IsTrue(Directory.Exists(folder));
+            data.DeleteAll();
+            Assert.IsFalse(Directory.Exists(folder));
+        }
+
     }
 }

--- a/src/test/Test.RazorEngine.Core/RazorEngineServiceTestFixture.cs
+++ b/src/test/Test.RazorEngine.Core/RazorEngineServiceTestFixture.cs
@@ -729,5 +729,28 @@ if ((Test.RazorEngine.RazorEngineServiceTestFixture.MyEnum)Model.State == Test.R
             Assert.IsFalse(compiledTemplate.CompilationData.SourceCode.Contains("#line hidden"));
         }
 
+
+        /// <summary>
+        /// Tests whether we can delete tempfiles when DisableTempFileLocking is true.
+        /// </summary>
+        [Test]
+        public void RazorEngineService_TestThatWeThrowWhenDebugAndDisableLockingAreEnabled()
+        {
+            var template = "@Model.Property";
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                RazorEngineServiceTestFixture.RunTestHelper(service =>
+                {
+                    var model = new { Property = 0 };
+                    string result = service.RunCompile(template, "key", null, model);
+                    Assert.AreEqual("0", result.Trim());
+                }, config =>
+                {
+                    config.Debug = true;
+                    config.DisableTempFileLocking = true;
+                });
+            });
+        }
+
     }
 }


### PR DESCRIPTION
Adds an option to use the <3.5 behavior, which is to load assemblies via `byte[]`.
As this has several drawbacks (including debugging, memory leaks, and security) this option is disabled by default, but there is a limited amount of scenarios where this behavior makes sense:

 * Your templates are limited in number.
 * You fully trust your templates / don't need isolation.
 * You don't need any kind of debugging support.
 * Your templates do not change in runtime.
