### PR TITLE
Remove periods from links to issues

### DIFF
--- a/ReleaseNotes.html
+++ b/ReleaseNotes.html
@@ -38,7 +38,7 @@
 <h3><a name="3-7-0-4-2-0-beta2" class="anchor" href="#3-7-0-4-2-0-beta2">3.7.0 / 4.2.0-beta2</a></h3>
 
 <ul>
-<li>add InvalidatingCachingProvider, ResolvePathTemplateManager and WatchingResolvePathTemplateManager, fixes <a href="https://github.com/Antaris/RazorEngine/issues/250.">https://github.com/Antaris/RazorEngine/issues/250.</a></li>
+<li>add InvalidatingCachingProvider, ResolvePathTemplateManager and WatchingResolvePathTemplateManager, fixes <a href="https://github.com/Antaris/RazorEngine/issues/250">https://github.com/Antaris/RazorEngine/issues/250</a></li>
 <li>Switched to Apache 2: <a href="https://github.com/Antaris/RazorEngine/issues/190">https://github.com/Antaris/RazorEngine/issues/190</a></li>
 <li>Missing feature (compared to 3.6): Configuration fallback to XML.</li>
 </ul>
@@ -72,14 +72,14 @@ Note that this can introduce memory leaks to your application.</li>
 <li>Cleanup temporary files when RazorEngine is not used in the default AppDomain</li>
 <li>Write to stderr when cleanup is not successful.</li>
 <li>Add an API to change the temporary directory (by subclassing CompilerService)</li>
-<li>Fix <a href="https://github.com/Antaris/RazorEngine/issues/253.">https://github.com/Antaris/RazorEngine/issues/253.</a></li>
+<li>Fix <a href="https://github.com/Antaris/RazorEngine/issues/253">https://github.com/Antaris/RazorEngine/issues/253</a></li>
 </ul>
 
 <h3><a name="3-6-3-beta2" class="anchor" href="#3-6-3-beta2">3.6.3-beta2</a></h3>
 
 <ul>
 <li>Fix some race conditions in cleanup.</li>
-<li>Fix <a href="https://github.com/Antaris/RazorEngine/issues/253.">https://github.com/Antaris/RazorEngine/issues/253.</a></li>
+<li>Fix <a href="https://github.com/Antaris/RazorEngine/issues/253">https://github.com/Antaris/RazorEngine/issues/253</a></li>
 </ul>
 
 <h3><a name="3-6-3-beta1-4-1-3-beta1" class="anchor" href="#3-6-3-beta1-4-1-3-beta1">3.6.3-beta1 / 4.1.3-beta1</a></h3>


### PR DESCRIPTION
The ReleaseNotes page contains several links to issues with extraneous periods at the end, causing a 404 when clicking on them.

Trivial -- I know -- but I keep falling for it when visiting the page to review new releases.