### PR TITLE
Remove periods from links to issues so generated page is forever fixed

### DIFF
--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,6 +1,6 @@
 ﻿### 3.7.0 / 4.2.0-beta2
 
- * add InvalidatingCachingProvider, ResolvePathTemplateManager and WatchingResolvePathTemplateManager, fixes https://github.com/Antaris/RazorEngine/issues/250.
+ * add InvalidatingCachingProvider, ResolvePathTemplateManager and WatchingResolvePathTemplateManager, fixes https://github.com/Antaris/RazorEngine/issues/250
  * Switched to Apache 2: https://github.com/Antaris/RazorEngine/issues/190
  * Missing feature (compared to 3.6): Configuration fallback to XML.
 
@@ -22,11 +22,11 @@
 * Cleanup temporary files when RazorEngine is not used in the default AppDomain
 * Write to stderr when cleanup is not successful.
 * Add an API to change the temporary directory (by subclassing CompilerService)
-* Fix https://github.com/Antaris/RazorEngine/issues/253.
+* Fix https://github.com/Antaris/RazorEngine/issues/253
 
 ### 3.6.3-beta2
 * Fix some race conditions in cleanup.
-* Fix https://github.com/Antaris/RazorEngine/issues/253.
+* Fix https://github.com/Antaris/RazorEngine/issues/253
 
 ### 3.6.3-beta1 / 4.1.3-beta1
 * Cleanup temporary files when RazorEngine is not used in the default AppDomain


### PR DESCRIPTION
Fix the links in the base page so the auto generated ReleaseNotes page is fixed too.

Follow up from pull request #279.