### PR TITLE
Removed Debug Symbols not Working Limitation

### DIFF
--- a/doc/Roslyn.md
+++ b/doc/Roslyn.md
@@ -16,7 +16,6 @@ config.CompilerServiceFactory = new RazorEngine.Roslyn.RoslynCompilerServiceFact
 
 ## Known Limitation/Bugs
 
-- Debugging symbols do not work currently (If you know how Roslyn works please send a pull request!).
 - Debug symbols cannot be created on mono/unix:
 
          error: (0, 0) Unexpected error writing debug information -- 'The requested feature is not implemented.'


### PR DESCRIPTION
Removed debugging symbols not working as this seems to not be a problem. For example: I was able to use code on the issue below with minor change as I noted in my comment and was able to debug the template... So I assume this is no longer an issue. (?)

https://github.com/Antaris/RazorEngine/issues/315
