### PR TITLE
Template Run performance optimizations

### DIFF
--- a/src/source/RazorEngine.Core/Templating/TemplateBaseOfT.cs
+++ b/src/source/RazorEngine.Core/Templating/TemplateBaseOfT.cs
@@ -25,15 +25,15 @@
         /// </summary>
         protected TemplateBase()
         {
-            var hasDynamicAttribute = GetType().IsDefined(typeof (HasDynamicModelAttribute), true);
-            if (hasDynamicAttribute && typeof(T) == typeof(object))
-	        {
+            if (typeof(T) == typeof(object) &&
+                GetType().IsDefined(typeof (HasDynamicModelAttribute), true))
+            {
                 // It is possible that we think that we have a dynamic model 
                 // (because null was given and the attribute is in place), 
                 // but the template contains the @model directive and
                 // therefore we have a static typed template.
                 HasDynamicModel = true;
-	        }
+            }
         }
 
         #endregion


### PR DESCRIPTION
This patch returns back StringBuilder usage as was in older versions.
Casting with "as" was replaced with check by "is" operator.
Do not perform slow attribute inspection if passed model is not of type "object".
Related issue: https://github.com/Antaris/RazorEngine/issues/327