### PR TITLE
Fixed issue with the name 'Engine' does not exists in the current context

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All you need to do is use the static `Engine` class (the `Engine.Razor` instance
 // using RazorEngine.Templating; // Dont forget to include this.
 string template = "Hello @Model.Name, welcome to RazorEngine!";
 var result =
-	Engine.Razor.RunCompile(template, "templateKey", null, new { Name = "World" });
+	RazorEngine.Engine.Razor.RunCompile(template, "templateKey", null, new { Name = "World" });
 ```
 
 > The `RunCompile` method used here is an extension method and you need to open the `RazorEngine.Templating` namespace.


### PR DESCRIPTION
After following the sample code in the readme file, I was unable to compile the code with visual studio community 2015. I read the source code and found out that the Engine class lives in the RazorEngine namespace. I just added it and now works! 