### PR TITLE
Update IntellisenseAndResharper.md

### DIFF
--- a/doc/IntellisenseAndResharper.md
+++ b/doc/IntellisenseAndResharper.md
@@ -13,7 +13,7 @@ To get full intellisense you should use the `@inherits` directive like this:
 ```markup
 @using RazorEngine
 @using MyProject.Models
-@inherits TemplateBase<MyModel>
+@inherits Templating.TemplateBase<MyModel>
 <h1>Your Invoice @Model.InvoiceNumber</h1>
 <p>The great stuff you bought was:</p>
 <ul>


### PR DESCRIPTION
TemplateBase is in the RazorEngine.Templating namespace.
I don't know if this is a recent change, but not setting the full namespace makes Visual Studio angry.