### PR TITLE
support models which implement ISerializable with IsolatedRazorEngineService

### DIFF
--- a/src/source/RazorEngine.Core/Compilation/RazorDynamicObject.cs
+++ b/src/source/RazorEngine.Core/Compilation/RazorDynamicObject.cs
@@ -336,7 +336,8 @@
             var wrapper = new RazorDynamicObject(wrapped, allowMissingMembers);
             var interfaces =
                 wrapped.GetType().GetInterfaces()
-                .Where(t => t.IsPublic && t != typeof(IDynamicMetaObjectProvider))
+                // remove IDynamicMetaObjectProvider and ISerializable interfaces because ActLikeProxy does already implement them
+                .Where(t => t.IsPublic && t != typeof(IDynamicMetaObjectProvider) && t != typeof(ISerializable))
                 .Select(MapInterface).ToArray();
             if (interfaces.Length > 0)
             {

--- a/src/test/Test.RazorEngine.Core/IsolatedRazorEngineServiceTestFixture.cs
+++ b/src/test/Test.RazorEngine.Core/IsolatedRazorEngineServiceTestFixture.cs
@@ -531,6 +531,23 @@ File.WriteAllText(""$file$"", ""BAD DATA"");
         }
 
         /// <summary>
+        /// Tests that a simple template with an ISerializable model can be parsed within a sandbox.
+        /// </summary>
+        [Test]
+        public void IsolatedRazorEngineService_Sandbox_WithISerializableModel()
+        {
+            using (var service = IsolatedRazorEngineService.Create(SandboxCreator))
+            {
+                const string template = "<h1>Uri Host: @Model.Host</h1>";
+                const string expected = "<h1>Uri Host: example.com</h1>";
+
+                var model = new Uri("http://example.com");
+                var result = service.RunCompile(template, "test", null, (object)RazorDynamicObject.Create(model));
+                Assert.AreEqual(expected, result);
+            }
+        }
+
+        /// <summary>
         /// Tests that an isolated template service cannot use the same application domain as the 
         /// main application domain.
         /// </summary>


### PR DESCRIPTION
Without this fix the following exception would be thrown if a model (wrapped by `RazorDynamicObject`) implements the `System.Runtime.Serialization.ISerializable` interface. (E.g. `System.Uri`, `System.Collections.Generic.Dictionary`)

```
System.Runtime.Serialization.SerializationException ist aufgetreten.
Message: Exception thrown: "System.Runtime.Serialization.SerializationException" in mscorlib.dll
Additional Information: THe Assembly "RazorEngine.Compilation.ImpromptuInterfaceDynamicAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" could not be found.
```

---

The problem was that the dynamically generated type would reimplement `ISerializable` even though the `ActLikeProxy` class already implemented it. So `ActLikeProxy` never got serialized correctly.