### PR TITLE
fix memory leak in CompilerServiceBase by removing event handler in dispose

### DIFF
--- a/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
+++ b/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
@@ -384,6 +384,7 @@
 #pragma warning restore 0618 // Backwards Compat.
             foreach (var reference in references)
             {
+                context.References.Add(reference);
                 yield return reference;
             }
         }

--- a/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
+++ b/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
@@ -132,7 +132,9 @@
         /// All references we used until now.
         /// </summary>
         private HashSet<CompilerReference> references = new HashSet<CompilerReference>();
-        
+
+        private bool _disposed;
+
         #endregion
 
         #region Methods
@@ -438,6 +440,47 @@
                 inspector.Inspect(unit, ns, type, executeMethod);
         }
 #endif
+
+
+        /// <summary>
+        /// Cleans up the <see cref="CompilerServiceBase"/> instance.
+        /// </summary>
+        ~CompilerServiceBase()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Disposes the current instance.
+        /// </summary>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+            Dispose(true);
+        }
+
+        /// <summary>
+        /// Disposes the current instance via the disposable pattern.
+        /// </summary>
+        /// <param name="disposing">true when Dispose() was called manually.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            if (disposing)
+            {
+                Unregister();
+            }
+            _disposed = true;
+        }
+
+        [SecuritySafeCritical]
+        private void Unregister()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve -= CurrentDomain_AssemblyResolve;
+        }
+
         #endregion
     }
 }

--- a/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
+++ b/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
@@ -126,11 +126,6 @@
         /// </summary>
         public abstract string SourceFileExtension { get; }
 
-        /// <summary>
-        /// All references we used until now.
-        /// </summary>
-        private HashSet<CompilerReference> references = new HashSet<CompilerReference>();
-
         private bool _disposed;
 
         #endregion
@@ -389,7 +384,6 @@
 #pragma warning restore 0618 // Backwards Compat.
             foreach (var reference in references)
             {
-                this.references.Add(reference);
                 yield return reference;
             }
         }
@@ -412,15 +406,6 @@
                 inspector.Inspect(unit, ns, type, executeMethod);
         }
 #endif
-
-
-        /// <summary>
-        /// Cleans up the <see cref="CompilerServiceBase"/> instance.
-        /// </summary>
-        ~CompilerServiceBase()
-        {
-            Dispose(false);
-        }
 
         /// <summary>
         /// Disposes the current instance.

--- a/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
+++ b/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
@@ -83,8 +83,6 @@
             CodeLanguage = codeLanguage;
             MarkupParserFactory = markupParserFactory ?? new ParserBaseCreator(null);
             ReferenceResolver = new UseCurrentAssembliesReferenceResolver();
-
-            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
         }
         #endregion
 
@@ -138,32 +136,6 @@
         #endregion
 
         #region Methods
-
-        [SecurityCritical]
-        private Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
-        {
-            (new PermissionSet(PermissionState.Unrestricted)).Assert();
-            var assemblyName = args.Name;
-            // First try the loaded ones
-            foreach (var reference in references)
-            {
-                var assemblyReference = reference as RazorEngine.Compilation.ReferenceResolver.CompilerReference.DirectAssemblyReference;
-                if (assemblyReference != null && assemblyReference.Assembly.GetName().FullName == assemblyName)
-                {
-                    return assemblyReference.Assembly;
-                }
-            }
-            // Then try the files
-            foreach (var reference in references)
-            {
-                var fileReference = reference as RazorEngine.Compilation.ReferenceResolver.CompilerReference.FileReference;
-                if (fileReference != null && AssemblyName.GetAssemblyName(fileReference.File).FullName == assemblyName)
-                {
-                    return Assembly.LoadFrom(fileReference.File);
-                }
-            }
-            return null;
-        }
 
         /// <summary>
         /// Tries to create and return a unique temporary directory.
@@ -465,20 +437,7 @@
         /// <param name="disposing">true when Dispose() was called manually.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (_disposed)
-                return;
 
-            if (disposing)
-            {
-                Unregister();
-            }
-            _disposed = true;
-        }
-
-        [SecuritySafeCritical]
-        private void Unregister()
-        {
-            AppDomain.CurrentDomain.AssemblyResolve -= CurrentDomain_AssemblyResolve;
         }
 
         #endregion

--- a/src/source/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
+++ b/src/source/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
@@ -26,7 +26,7 @@
     /// <summary>
     /// Provides a base implementation of a direct compiler service.
     /// </summary>
-    public abstract class DirectCompilerServiceBase : CompilerServiceBase, IDisposable
+    public abstract class DirectCompilerServiceBase : CompilerServiceBase
     {
         #region Fields
         private readonly CodeDomProvider _codeDomProvider;
@@ -333,26 +333,20 @@
         }
 
         /// <summary>
-        /// Releases managed resourced used by this instance.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
         /// Releases managed resources used by this instance.
         /// </summary>
-        /// <param name="disposing">Are we explicily disposing of this instance?</param>
-        protected virtual void Dispose(bool disposing)
+        /// <param name="disposing"></param>
+        protected override void Dispose(bool disposing)
         {
             if (disposing && !_disposed)
             {
                 _codeDomProvider.Dispose();
                 _disposed = true;
             }
+
+            base.Dispose(disposing);
         }
+
         #endregion
     }
 }

--- a/src/source/RazorEngine.Core/Compilation/ICompilerService.cs
+++ b/src/source/RazorEngine.Core/Compilation/ICompilerService.cs
@@ -11,7 +11,7 @@
     /// <summary>
     /// Defines the required contract for implementing a compiler service.
     /// </summary>
-    public interface ICompilerService
+    public interface ICompilerService : IDisposable
     {
         #region Properties
 #if !RAZOR4

--- a/src/source/RazorEngine.Core/Compilation/ReferenceResolver/CompilerReference.cs
+++ b/src/source/RazorEngine.Core/Compilation/ReferenceResolver/CompilerReference.cs
@@ -130,6 +130,35 @@ namespace RazorEngine.Compilation.ReferenceResolver
         }
 
         /// <summary>
+        /// Default implementation for resolving an assembly name.
+        /// </summary>
+        /// <param name="assemblyName">name of the assembly to resolve</param>
+        /// <param name="references">references to check</param>
+        /// <returns>the resolved assembly or null</returns>
+        public static Assembly Resolve(string assemblyName, IEnumerable<CompilerReference> references)
+        {
+            // First try the loaded ones
+            foreach (var reference in references)
+            {
+                var assemblyReference = reference as DirectAssemblyReference;
+                if (assemblyReference != null && assemblyReference.Assembly.GetName().FullName == assemblyName)
+                {
+                    return assemblyReference.Assembly;
+                }
+            }
+            // Then try the files
+            foreach (var reference in references)
+            {
+                var fileReference = reference as FileReference;
+                if (fileReference != null && AssemblyName.GetAssemblyName(fileReference.File).FullName == assemblyName)
+                {
+                    return Assembly.LoadFrom(fileReference.File);
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
         /// Try to resolve the reference to a file (throws when this is not possible).
         /// </summary>
         /// <param name="exceptionCreator"></param>

--- a/src/source/RazorEngine.Core/Compilation/ReferenceResolver/CompilerReference.cs
+++ b/src/source/RazorEngine.Core/Compilation/ReferenceResolver/CompilerReference.cs
@@ -135,7 +135,7 @@ namespace RazorEngine.Compilation.ReferenceResolver
         /// <param name="assemblyName">name of the assembly to resolve</param>
         /// <param name="references">references to check</param>
         /// <returns>the resolved assembly or null</returns>
-        public static Assembly Resolve(string assemblyName, IEnumerable<CompilerReference> references)
+        internal static Assembly Resolve(string assemblyName, IEnumerable<CompilerReference> references)
         {
             // First try the loaded ones
             foreach (var reference in references)

--- a/src/source/RazorEngine.Core/Compilation/TypeContext.cs
+++ b/src/source/RazorEngine.Core/Compilation/TypeContext.cs
@@ -1,6 +1,7 @@
 ﻿namespace RazorEngine.Compilation
 {
     using RazorEngine.Templating;
+    using ReferenceResolver;
     using System;
     using System.Collections.Generic;
 
@@ -56,6 +57,11 @@
         /// Gets or sets the base template type.
         /// </summary>
         public Type TemplateType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the compiler references
+        /// </summary>
+        public ISet<CompilerReference> References { get; set; }
         #endregion
     }
 }

--- a/src/source/RazorEngine.Core/Templating/RazorEngineCore.cs
+++ b/src/source/RazorEngine.Core/Templating/RazorEngineCore.cs
@@ -106,21 +106,21 @@ namespace RazorEngine.Templating
             foreach (string ns in _config.Namespaces)
                 context.Namespaces.Add(ns);
 
-            var service = _config
-                .CompilerServiceFactory
-                .CreateCompilerService(_config.Language);
-            service.Debug = _config.Debug;
-            service.DisableTempFileLocking = _config.DisableTempFileLocking;
+            using (var service = _config.CompilerServiceFactory.CreateCompilerService(_config.Language))
+            {
+                service.Debug = _config.Debug;
+                service.DisableTempFileLocking = _config.DisableTempFileLocking;
 #if !RAZOR4
 #pragma warning disable 0618 // Backwards Compat.
-            service.CodeInspectors = _config.CodeInspectors ?? Enumerable.Empty<ICodeInspector>();
+                service.CodeInspectors = _config.CodeInspectors ?? Enumerable.Empty<ICodeInspector>();
 #pragma warning restore 0618 // Backwards Compat.
 #endif
-            service.ReferenceResolver = _config.ReferenceResolver ?? new UseCurrentAssembliesReferenceResolver();
+                service.ReferenceResolver = _config.ReferenceResolver ?? new UseCurrentAssembliesReferenceResolver();
 
-            var result = service.CompileType(context);
+                var result = service.CompileType(context);
 
-            return result;
+                return result;
+            }
         }
 
 

--- a/src/source/RazorEngine.Core/Templating/RazorEngineService.cs
+++ b/src/source/RazorEngine.Core/Templating/RazorEngineService.cs
@@ -1,11 +1,9 @@
-﻿using RazorEngine.Compilation.ReferenceResolver;
-using RazorEngine.Configuration;
+﻿using RazorEngine.Configuration;
 using RazorEngine.Text;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using System.Reflection;
 #if RAZOR4
 using System.Runtime.ExceptionServices;
 #endif
@@ -36,7 +34,6 @@ namespace RazorEngine.Templating
         /// Initialises a new instance of <see cref="TemplateService"/>
         /// </summary>
         /// <param name="config">The template service configuration.</param>
-        [SecuritySafeCritical]
         internal RazorEngineService(ITemplateServiceConfiguration config)
         {
             if (config == null)
@@ -51,12 +48,6 @@ namespace RazorEngine.Templating
             _config = config;
             //_core = new RazorEngineCore(config, this);
             _core_with_cache = new RazorEngineCoreWithCache(new ReadOnlyTemplateServiceConfiguration(config), this);
-            AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve;
-        }
-
-        private Assembly AssemblyResolve(object sender, ResolveEventArgs args)
-        {
-            return CompilerReference.Resolve(args.Name, _config.ReferenceResolver.GetReferences(null));
         }
 
         /// <summary>
@@ -139,13 +130,12 @@ namespace RazorEngine.Templating
         /// Releases managed resources used by this instance.
         /// </summary>
         /// <param name="disposing">Are we explicitly disposing of this instance?</param>
-        [SecuritySafeCritical]
         protected override void Dispose(bool disposing)
         {
             if (!disposed && disposing)
             {
-                AppDomain.CurrentDomain.AssemblyResolve -= AssemblyResolve;
                 _config.CachingProvider.Dispose();
+                _core_with_cache.Dispose();
                 disposed = true;
             }
             base.Dispose(disposing);


### PR DESCRIPTION
`ICompilerService` now implements `IDisposable` so all implementing classes can be properly disposed.
This is required to prevent a memory leak within `CompilerServiceBase` which previously did not unregister the `AssemblyResolve` event handler.
Also the `Dispose` method of `DirectCompilerServiceBase` was never called which disposes the CodeDomProvider. (There was also a nice comment: `Are we explicily disposing of this instance?`)

Here is a screenshot from .NET Memory Profile before this fix:
![image](https://cloud.githubusercontent.com/assets/4009570/15647423/c425b6d4-2663-11e6-8d12-b3873136fcb1.png)
The red line are the CompilerServices.
The orange line are the CodeDomProviders from `DirectCompilerServiceBase`.

After this fix these objects were properly gced.