### PR TITLE
A fix for huge memory usage for larger files.

### DIFF
--- a/src/source/RazorEngine.Core/Templating/TemplateBase.cs
+++ b/src/source/RazorEngine.Core/Templating/TemplateBase.cs
@@ -135,7 +135,7 @@ namespace RazorEngine.Templating
         /// <returns>The template writer helper.</returns>
         public virtual TemplateWriter Include(string name, object model = null, Type modelType = null)
         {
-            var instance = InternalTemplateService.Resolve(name, model, modelType, (DynamicViewBag) ViewBag, ResolveType.Include);
+            var instance = InternalTemplateService.Resolve(name, model, modelType, (DynamicViewBag)ViewBag, ResolveType.Include);
             if (instance == null)
                 throw new ArgumentException("No template could be resolved with name '" + name + "'");
 
@@ -146,7 +146,7 @@ namespace RazorEngine.Templating
 #if RAZOR4
                     .Wait()
 #endif
-                    );
+);
         }
 
         /// <summary>
@@ -246,21 +246,21 @@ namespace RazorEngine.Templating
 
                     var body = new TemplateWriter(
                         tw =>
+                        {
+                            var buffer = new char[2000];
+                            using (var reader = new StreamReader(tempFilePath))
                             {
-                                var buffer = new char[2000];
-                                using (var reader = new StreamReader(tempFilePath))
+                                // Push the current body instance onto the stack for later execution.
+                                while (!reader.EndOfStream)
                                 {
-                                    // Push the current body instance onto the stack for later execution.
-                                    while ( !reader.EndOfStream)
-                                    {
-                                        var charsRead = reader.Read(buffer, 0, 1000);
-                                        tw.Write(buffer, 0, charsRead);
-                                    }
+                                    var charsRead = reader.Read(buffer, 0, 2000);
+                                    tw.Write(buffer, 0, charsRead);
                                 }
-                            });
-                        
-                        context.PushBody(body);
-                    
+                            }
+                        });
+
+                    context.PushBody(body);
+
                     context.PushSections();
 
 #if RAZOR4
@@ -277,7 +277,7 @@ namespace RazorEngine.Templating
                     // Push the current body instance onto the stack for later execution.
                     while (!reader.EndOfStream)
                     {
-                        var charsRead = reader.Read(buffer, 0, 1000);
+                        var charsRead = reader.Read(buffer, 0, 2000);
                         outputWriter.Write(buffer, 0, charsRead);
                     }
                 }
@@ -303,14 +303,15 @@ namespace RazorEngine.Templating
             if (action == null && required)
                 throw new ArgumentException("No section has been defined with name '" + name + "'");
 
-            if (action == null) 
+            if (action == null)
 #if RAZOR4
                 action = (tw) => { };
 #else
                 action = () => { };
 #endif
 
-            return new TemplateWriter(tw => {
+            return new TemplateWriter(tw =>
+            {
                 _context.PopSections(action, tw);
             });
         }

--- a/src/source/RazorEngine.Core/Templating/TemplateBase.cs
+++ b/src/source/RazorEngine.Core/Templating/TemplateBase.cs
@@ -217,7 +217,7 @@ namespace RazorEngine.Templating
         {
             _context = context;
 
-            string tempFilePath = Path.GetTempPath();
+            string tempFilePath = Path.GetTempFileName();
 
             try
             {

--- a/src/source/RazorEngine.Core/Templating/TemplateBase.cs
+++ b/src/source/RazorEngine.Core/Templating/TemplateBase.cs
@@ -231,41 +231,41 @@ namespace RazorEngine.Templating
 #endif
                     writer.Flush();
                     _context.CurrentWriter = null;
+                }
 
+                if (Layout != null)
+                {
+                    // Get the layout template.
+                    var layout = ResolveLayout(Layout);
 
-                    if (Layout != null)
+                    if (layout == null)
                     {
-                        // Get the layout template.
-                        var layout = ResolveLayout(Layout);
-
-                        if (layout == null)
-                        {
-                            throw new ArgumentException(
-                                "Template you are trying to run uses layout, but no layout found in cache or by resolver.");
-                        }
-
-                        using (var reader = new StreamReader(tempFilePath))
-                        {
-                            // Push the current body instance onto the stack for later execution.
-                            var body = new TemplateWriter(tw => tw.Write(reader));
-                            context.PushBody(body);
-                        }
-
-                        context.PushSections();
-
-#if RAZOR4
-                    await layout.Run(context, outputWriter);
-#else
-                        layout.Run(context, outputWriter);
-#endif
-                        return;
+                        throw new ArgumentException(
+                            "Template you are trying to run uses layout, but no layout found in cache or by resolver.");
                     }
 
                     using (var reader = new StreamReader(tempFilePath))
                     {
-                        outputWriter.Write(reader);
+                        // Push the current body instance onto the stack for later execution.
+                        var body = new TemplateWriter(tw => tw.Write(reader));
+                        context.PushBody(body);
                     }
+
+                    context.PushSections();
+
+#if RAZOR4
+                    await layout.Run(context, outputWriter);
+#else
+                    layout.Run(context, outputWriter);
+#endif
+                    return;
                 }
+
+                using (var reader = new StreamReader(tempFilePath))
+                {
+                    outputWriter.Write(reader);
+                }
+
             }
             finally
             {

--- a/src/source/RazorEngine.Core/Templating/TemplateBase.cs
+++ b/src/source/RazorEngine.Core/Templating/TemplateBase.cs
@@ -210,9 +210,9 @@ namespace RazorEngine.Templating
         /// <param name="reader"></param>
         /// <returns>The merged result of the template.</returns>
 #if RAZOR4
-        public async Task Run(ExecuteContext context, TextWriter reader)
+        public async Task Run(ExecuteContext context, TextWriter outputWriter)
 #else
-        void ITemplate.Run(ExecuteContext context, TextWriter reader)
+        void ITemplate.Run(ExecuteContext context, TextWriter outputWriter)
 #endif
         {
             _context = context;
@@ -261,14 +261,14 @@ namespace RazorEngine.Templating
                     context.PushSections();
 
 #if RAZOR4
-                    await layout.Run(context, reader);
+                    await layout.Run(context, outputWriter);
 #else
-                    layout.Run(context, reader);
+                    layout.Run(context, outputWriter);
 #endif
                     return;
                 }
 
-                reader.Write(builder.ToString());
+                outputWriter.Write(builder.ToString());
             }
         }
 

--- a/src/source/RazorEngine.Core/Templating/TemplateBase.cs
+++ b/src/source/RazorEngine.Core/Templating/TemplateBase.cs
@@ -247,12 +247,14 @@ namespace RazorEngine.Templating
                     var body = new TemplateWriter(
                         tw =>
                             {
+                                var buffer = new char[2000];
                                 using (var reader = new StreamReader(tempFilePath))
                                 {
                                     // Push the current body instance onto the stack for later execution.
                                     while ( !reader.EndOfStream)
                                     {
-                                        tw.WriteLine(reader.ReadLine());
+                                        var charsRead = reader.Read(buffer, 0, 1000);
+                                        tw.Write(buffer, 0, charsRead);
                                     }
                                 }
                             });
@@ -271,10 +273,12 @@ namespace RazorEngine.Templating
 
                 using (var reader = new StreamReader(tempFilePath))
                 {
+                    var buffer = new char[2000];
                     // Push the current body instance onto the stack for later execution.
                     while (!reader.EndOfStream)
                     {
-                        outputWriter.WriteLine(reader.ReadLine());
+                        var charsRead = reader.Read(buffer, 0, 1000);
+                        outputWriter.Write(buffer, 0, charsRead);
                     }
                 }
             }

--- a/src/source/RazorEngine.Core/Templating/TemplateBase.cs
+++ b/src/source/RazorEngine.Core/Templating/TemplateBase.cs
@@ -244,13 +244,21 @@ namespace RazorEngine.Templating
                             "Template you are trying to run uses layout, but no layout found in cache or by resolver.");
                     }
 
-                    using (var reader = new StreamReader(tempFilePath))
-                    {
-                        // Push the current body instance onto the stack for later execution.
-                        var body = new TemplateWriter(tw => tw.Write(reader));
+                    var body = new TemplateWriter(
+                        tw =>
+                            {
+                                using (var reader = new StreamReader(tempFilePath))
+                                {
+                                    // Push the current body instance onto the stack for later execution.
+                                    while ( !reader.EndOfStream)
+                                    {
+                                        tw.Write(reader.ReadLine());
+                                    }
+                                }
+                            });
+                        
                         context.PushBody(body);
-                    }
-
+                    
                     context.PushSections();
 
 #if RAZOR4
@@ -263,7 +271,11 @@ namespace RazorEngine.Templating
 
                 using (var reader = new StreamReader(tempFilePath))
                 {
-                    outputWriter.Write(reader);
+                    // Push the current body instance onto the stack for later execution.
+                    while (!reader.EndOfStream)
+                    {
+                        outputWriter.Write(reader.ReadLine());
+                    }
                 }
 
             }

--- a/src/source/RazorEngine.Core/Templating/TemplateBase.cs
+++ b/src/source/RazorEngine.Core/Templating/TemplateBase.cs
@@ -252,7 +252,7 @@ namespace RazorEngine.Templating
                                     // Push the current body instance onto the stack for later execution.
                                     while ( !reader.EndOfStream)
                                     {
-                                        tw.Write(reader.ReadLine());
+                                        tw.WriteLine(reader.ReadLine());
                                     }
                                 }
                             });
@@ -274,10 +274,9 @@ namespace RazorEngine.Templating
                     // Push the current body instance onto the stack for later execution.
                     while (!reader.EndOfStream)
                     {
-                        outputWriter.Write(reader.ReadLine());
+                        outputWriter.WriteLine(reader.ReadLine());
                     }
                 }
-
             }
             finally
             {

--- a/src/source/RazorEngine.Core/Templating/TemplateBase.cs
+++ b/src/source/RazorEngine.Core/Templating/TemplateBase.cs
@@ -207,7 +207,7 @@ namespace RazorEngine.Templating
         /// Runs the template and returns the result.
         /// </summary>
         /// <param name="context">The current execution context.</param>
-        /// <param name="reader"></param>
+        /// <param name="outputWriter"></param>
         /// <returns>The merged result of the template.</returns>
 #if RAZOR4
         public async Task Run(ExecuteContext context, TextWriter outputWriter)

--- a/src/source/RazorEngine.Core/Templating/TemplateBase.cs
+++ b/src/source/RazorEngine.Core/Templating/TemplateBase.cs
@@ -216,6 +216,21 @@ namespace RazorEngine.Templating
 #endif
         {
             _context = context;
+			
+			// If there's no layout defined, then write directly to the output writer.
+            if (Layout == null)
+            {
+                _context.CurrentWriter = outputWriter;
+#if RAZOR4
+                await Execute();
+#else
+                Execute();
+#endif
+                outputWriter.Flush();
+                _context.CurrentWriter = null;
+
+                return;
+            }
 
             StringBuilder builder = new StringBuilder();
             using (var writer = new StringWriter(builder))


### PR DESCRIPTION
What if there's no layout the result would be written directly to output stream?

I run into out of memory error while generating large files using RazorEngine.
