### PR TITLE
support AspNetCore.Razor 1.0.0

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -21,8 +21,7 @@ group Razor4
   condition: RAZOR4
   source https://nuget.org/api/v2
 
-// We should update to rc1, however they always break a lot... If you come here and have some time please update me
-  nuget Microsoft.AspNet.Razor = 4.0.0-beta7
+  nuget Microsoft.AspNetCore.Razor ~> 1.0
   nuget Microsoft.CodeAnalysis != 1.0.0-rc2
 
 group Test

--- a/paket.lock
+++ b/paket.lock
@@ -59,7 +59,7 @@ CONDITION: RAZOR4
 NUGET
   remote: https://nuget.org/api/v2
   specs:
-    Microsoft.AspNet.Razor (4.0.0-beta7)
+    Microsoft.AspNetCore.Razor (1.0.0)
       System.Collections (>= 4.0.11-beta-23225) - framework: dnxcore50
       System.Diagnostics.Debug (>= 4.0.11-beta-23225) - framework: dnxcore50
       System.Diagnostics.Tools (>= 4.0.1-beta-23225) - framework: dnxcore50

--- a/src/source/RazorEngine.Core.Roslyn/CSharp/CSharpRoslynCompilerService.cs
+++ b/src/source/RazorEngine.Core.Roslyn/CSharp/CSharpRoslynCompilerService.cs
@@ -1,5 +1,5 @@
 ﻿#if RAZOR4
-using Microsoft.AspNet.Razor.Parser;
+using Microsoft.AspNetCore.Razor.Parser;
 #else
 using System.Web.Razor.Parser;
 #endif

--- a/src/source/RazorEngine.Core.Roslyn/RazorEngine.Core.Roslyn.csproj
+++ b/src/source/RazorEngine.Core.Roslyn/RazorEngine.Core.Roslyn.csproj
@@ -59,6 +59,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|Razor4' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -70,6 +71,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|Razor4' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <RAZOR4>True</RAZOR4>
@@ -363,8 +365,8 @@
   <Choose>
     <When Condition="'$(RAZOR4)' == 'True' And ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1'))">
       <ItemGroup>
-        <Reference Include="Microsoft.AspNet.Razor">
-          <HintPath>..\..\..\packages\razor4\Microsoft.AspNet.Razor\lib\net45\Microsoft.AspNet.Razor.dll</HintPath>
+        <Reference Include="Microsoft.AspNetCore.Razor">
+          <HintPath>..\..\..\packages\razor4\Microsoft.AspNetCore.Razor\lib\net451\Microsoft.AspNetCore.Razor.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/source/RazorEngine.Core.Roslyn/RazorEngine.Core.Roslyn.csproj
+++ b/src/source/RazorEngine.Core.Roslyn/RazorEngine.Core.Roslyn.csproj
@@ -82,7 +82,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly Condition=" '$(Platform)' != 'Razor4' ">true</SignAssembly>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>RazorEngine.snk</AssemblyOriginatorKeyFile>

--- a/src/source/RazorEngine.Core.Roslyn/RoslynCompilerServiceBase.cs
+++ b/src/source/RazorEngine.Core.Roslyn/RoslynCompilerServiceBase.cs
@@ -7,8 +7,8 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 #if RAZOR4
-using Microsoft.AspNet.Razor.Parser;
-using Microsoft.AspNet.Razor;
+using Microsoft.AspNetCore.Razor.Parser;
+using Microsoft.AspNetCore.Razor;
 #else
 using System.Web.Razor.Parser;
 using System.Web.Razor;
@@ -30,7 +30,7 @@ namespace RazorEngine.Roslyn.CSharp
     {
         private class SelectMetadataReference : CompilerReference.ICompilerReferenceVisitor<MetadataReference>
         {
-            public MetadataReference Visit(System.Reflection.Assembly assembly)
+            public MetadataReference Visit(Assembly assembly)
             {
                 return MetadataReference.CreateFromAssembly(assembly);
             }
@@ -40,7 +40,7 @@ namespace RazorEngine.Roslyn.CSharp
                 return MetadataReference.CreateFromFile(file);
             }
 
-            public MetadataReference Visit(System.IO.Stream stream)
+            public MetadataReference Visit(Stream stream)
             {
                 return MetadataReference.CreateFromStream(stream);
             }
@@ -213,8 +213,8 @@ namespace RazorEngine.Roslyn.CSharp
             var assemblyPdbFile = Path.Combine(tempDir, String.Format("{0}.pdb", assemblyName));
             var compilationData = new CompilationData(sourceCode, tempDir);
             
-            using (var assemblyStream = File.OpenWrite(assemblyFile))
-            using (var pdbStream = File.OpenWrite(assemblyPdbFile))
+            using (var assemblyStream = File.Open(assemblyFile, FileMode.Create, FileAccess.ReadWrite))
+            using (var pdbStream = File.Open(assemblyPdbFile, FileMode.Create, FileAccess.ReadWrite))
             {
                 var opts = new EmitOptions().WithPdbFilePath(assemblyPdbFile);
                 var pdbStreamHelper = pdbStream;
@@ -235,7 +235,7 @@ namespace RazorEngine.Roslyn.CSharp
                                 lineSpan.StartLinePosition.Line, 
                                 lineSpan.StartLinePosition.Character, 
                                 diag.Id, 
-                                diag.Severity != DiagnosticSeverity.Error); ;
+                                diag.Severity != DiagnosticSeverity.Error);
                         });
                             
                     throw new Templating.TemplateCompilationException(errors, compilationData, context.TemplateContent);

--- a/src/source/RazorEngine.Core.Roslyn/paket.references
+++ b/src/source/RazorEngine.Core.Roslyn/paket.references
@@ -6,5 +6,5 @@ group Net40
   Microsoft.AspNet.Razor
 
 group Razor4
-  Microsoft.AspNet.Razor
+  Microsoft.AspNetCore.Razor
   Microsoft.CodeAnalysis

--- a/src/source/RazorEngine.Core/CodeGenerators/SetModelTypeCodeGenerator.cs
+++ b/src/source/RazorEngine.Core/CodeGenerators/SetModelTypeCodeGenerator.cs
@@ -3,8 +3,8 @@
     using System;
     using System.Globalization;
 #if RAZOR4
-    using Microsoft.AspNet.Razor.Chunks.Generators;
-    using Microsoft.AspNet.Razor.Parser.SyntaxTree;
+    using Microsoft.AspNetCore.Razor.Chunks.Generators;
+    using Microsoft.AspNetCore.Razor.Parser.SyntaxTree;
 #else
     using System.Web.Razor.Generator;
 #endif

--- a/src/source/RazorEngine.Core/Compilation/CSharp/CSharpCodeParser.cs
+++ b/src/source/RazorEngine.Core/Compilation/CSharp/CSharpCodeParser.cs
@@ -1,11 +1,11 @@
 ﻿namespace RazorEngine.Compilation.CSharp
 {
 #if RAZOR4
-    using Microsoft.AspNet.Razor;
-    using Microsoft.AspNet.Razor.Chunks.Generators;
-    using Microsoft.AspNet.Razor.Text;
-    using Microsoft.AspNet.Razor.Parser;
-    using RazorCSharpCodeParser = Microsoft.AspNet.Razor.Parser.CSharpCodeParser;
+    using Microsoft.AspNetCore.Razor;
+    using Microsoft.AspNetCore.Razor.Chunks.Generators;
+    using Microsoft.AspNetCore.Razor.Text;
+    using Microsoft.AspNetCore.Razor.Parser;
+    using RazorCSharpCodeParser = Microsoft.AspNetCore.Razor.Parser.CSharpCodeParser;
 #else
     using System.Web.Razor.Generator;
     using System.Web.Razor.Text;
@@ -60,7 +60,11 @@
         {
             if (_modelStatementFound && _endInheritsLocation.HasValue)
             {
-                Context.OnError(_endInheritsLocation.Value, "The 'inherits' keyword is not allowed when a 'model' keyword is used.");
+                Context.OnError(_endInheritsLocation.Value, "The 'inherits' keyword is not allowed when a 'model' keyword is used."
+#if RAZOR4
+                    , 0
+#endif
+                );
             }
         }
 
@@ -82,7 +86,11 @@
 
             if (_modelStatementFound)
             {
-                Context.OnError(endModelLocation, "Only one 'model' statement is allowed in a file.");
+                Context.OnError(endModelLocation, "Only one 'model' statement is allowed in a file."
+#if RAZOR4
+                    , 0
+#endif
+                );
             }
 
             _modelStatementFound = true;

--- a/src/source/RazorEngine.Core/Compilation/CSharp/CSharpDirectCompilerService.cs
+++ b/src/source/RazorEngine.Core/Compilation/CSharp/CSharpDirectCompilerService.cs
@@ -5,7 +5,7 @@
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
 #if RAZOR4
-    using Microsoft.AspNet.Razor.Parser;
+    using Microsoft.AspNetCore.Razor.Parser;
 #else
     using System.Web.Razor.Parser;
 #endif

--- a/src/source/RazorEngine.Core/Compilation/CSharp/CSharpRazorCodeGenerator.cs
+++ b/src/source/RazorEngine.Core/Compilation/CSharp/CSharpRazorCodeGenerator.cs
@@ -6,10 +6,10 @@ namespace RazorEngine.Compilation.CSharp
     using System.CodeDom;
     using System.Security;
 #if RAZOR4
-    using Microsoft.AspNet.Razor;
-    using Microsoft.AspNet.Razor.CodeGenerators;
-    using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-    using OriginalCSharpRazorCodeGenerator = Microsoft.AspNet.Razor.Chunks.Generators.RazorChunkGenerator;
+    using Microsoft.AspNetCore.Razor;
+    using Microsoft.AspNetCore.Razor.CodeGenerators;
+    using Microsoft.AspNetCore.Razor.Parser.SyntaxTree;
+    using OriginalCSharpRazorCodeGenerator = Microsoft.AspNetCore.Razor.Chunks.Generators.RazorChunkGenerator;
 #else
     using System.Web.Razor;
     using System.Web.Razor.Parser.SyntaxTree;

--- a/src/source/RazorEngine.Core/Compilation/CSharp/CSharpRazorCodeLanguage.cs
+++ b/src/source/RazorEngine.Core/Compilation/CSharp/CSharpRazorCodeLanguage.cs
@@ -2,9 +2,9 @@
 {
     using System.Security;
 #if RAZOR4
-    using Microsoft.AspNet.Razor;
-    using Microsoft.AspNet.Razor.Chunks.Generators;
-    using OriginalCSharpRazorCodeLanguage = Microsoft.AspNet.Razor.CSharpRazorCodeLanguage;
+    using Microsoft.AspNetCore.Razor;
+    using Microsoft.AspNetCore.Razor.Chunks.Generators;
+    using OriginalCSharpRazorCodeLanguage = Microsoft.AspNetCore.Razor.CSharpRazorCodeLanguage;
 #else
     using System.Web.Razor;
     using System.Web.Razor.Generator;

--- a/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
+++ b/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
@@ -8,10 +8,10 @@
     using System.Linq;
     using System.Reflection;
 #if RAZOR4
-    using Microsoft.AspNet.Razor;
-    using Microsoft.AspNet.Razor.CodeGenerators;
-    using Microsoft.AspNet.Razor.Chunks.Generators;
-    using Microsoft.AspNet.Razor.Parser;
+    using Microsoft.AspNetCore.Razor;
+    using Microsoft.AspNetCore.Razor.CodeGenerators;
+    using Microsoft.AspNetCore.Razor.Parser;
+    using Microsoft.AspNetCore.Razor.Parser.Internal;
 #else
     using System.Web.Razor;
     using System.Web.Razor.Generator;
@@ -227,12 +227,12 @@
                             ResolveUrlMethodName = "ResolveUrl"
                         }
 #endif
-            };
+                };
 
             return host;
         }
 
-        
+
         /// <summary>
         /// Gets the source code from Razor for the given template.
         /// </summary>
@@ -300,7 +300,7 @@
 
             if (template == null)
                 throw new ArgumentException("Template is required.");
-            
+
             namespaceImports = namespaceImports ?? new HashSet<string>();
             templateType = templateType ?? ((modelType == null) ? typeof(TemplateBase) : typeof(TemplateBase<>));
 

--- a/src/source/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
+++ b/src/source/RazorEngine.Core/Compilation/DirectCompilerServiceBase.cs
@@ -13,9 +13,9 @@
     using System.Security.Permissions;
     using System.Text;
 #if RAZOR4
-    using Microsoft.AspNet.Razor;
-    using Microsoft.AspNet.Razor.CodeGenerators;
-    using Microsoft.AspNet.Razor.Parser;
+    using Microsoft.AspNetCore.Razor;
+    using Microsoft.AspNetCore.Razor.CodeGenerators;
+    using Microsoft.AspNetCore.Razor.Parser;
 #else
     using System.Web.Razor;
     using System.Web.Razor.Parser;
@@ -118,14 +118,14 @@
                 if (!written)
                 {
                     foreach (string item in results.TempFiles)
-	                {
+                    {
                         if (item.EndsWith("." + this.SourceFileExtension))
                         {
                             File.Copy(item, targetFile, true);
                             written = true;
                             break;
                         }
-	                } 
+                    } 
                 }
             }
             return Tuple.Create(results, sourceCode);

--- a/src/source/RazorEngine.Core/Compilation/RazorEngineHost.cs
+++ b/src/source/RazorEngine.Core/Compilation/RazorEngineHost.cs
@@ -3,9 +3,9 @@
     using System;
     using System.Security;
 #if RAZOR4
-    using Microsoft.AspNet.Razor;
-    using Microsoft.AspNet.Razor.Parser;
-    using OriginalRazorEngineHost = Microsoft.AspNet.Razor.RazorEngineHost;
+    using Microsoft.AspNetCore.Razor;
+    using Microsoft.AspNetCore.Razor.Parser;
+    using OriginalRazorEngineHost = Microsoft.AspNetCore.Razor.RazorEngineHost;
 #else
     using System.Web.Razor;
     using System.Web.Razor.Parser;

--- a/src/source/RazorEngine.Core/Properties/AssemblyInfo.cs
+++ b/src/source/RazorEngine.Core/Properties/AssemblyInfo.cs
@@ -18,12 +18,7 @@ using System.Security;
 [assembly: Guid("c11064c2-11b8-420b-81f0-4c6477cb5931")]
 
 // Allow the test assembly access to internals.
-#if RAZOR4
-[assembly: InternalsVisibleTo("Test.RazorEngine.Core")]
-[assembly: InternalsVisibleTo("Test.RazorEngine.Core.Roslyn")]
-#else
 [assembly: InternalsVisibleTo("Test.RazorEngine.Core, PublicKey=0024000004800000940000000602000000240000525341310004000001000100ad3b3604eb9ba317840ece0a65ec22fa67ee54cb4abb5148f184a90d9e9cdbc77c098fe3447ce9e13ef73d3e046016e7053f4c5c0ccd9f521514200dd09aa12cedc63bf39c30eb0516ac6b42bb645dfd41902290a87ceaf0309a9f08bfdd9cceb27b6186bfbe68ca91dca2508820c0723b0e4d94f3ef8049b8aa3f524d4715ca")]
 [assembly: InternalsVisibleTo("Test.RazorEngine.Core.Roslyn, PublicKey=0024000004800000940000000602000000240000525341310004000001000100ad3b3604eb9ba317840ece0a65ec22fa67ee54cb4abb5148f184a90d9e9cdbc77c098fe3447ce9e13ef73d3e046016e7053f4c5c0ccd9f521514200dd09aa12cedc63bf39c30eb0516ac6b42bb645dfd41902290a87ceaf0309a9f08bfdd9cceb27b6186bfbe68ca91dca2508820c0723b0e4d94f3ef8049b8aa3f524d4715ca")]
-#endif
 
 [assembly: AllowPartiallyTrustedCallers]

--- a/src/source/RazorEngine.Core/RazorEngine.Core.csproj
+++ b/src/source/RazorEngine.Core/RazorEngine.Core.csproj
@@ -120,6 +120,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|Razor4' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <Platform>Razor4</Platform>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -158,6 +159,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|Razor4' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <Platform>Razor4</Platform>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -383,8 +385,8 @@
   <Choose>
     <When Condition="'$(RAZOR4)' == 'True' And ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1'))">
       <ItemGroup>
-        <Reference Include="Microsoft.AspNet.Razor">
-          <HintPath>..\..\..\packages\razor4\Microsoft.AspNet.Razor\lib\net45\Microsoft.AspNet.Razor.dll</HintPath>
+        <Reference Include="Microsoft.AspNetCore.Razor">
+          <HintPath>..\..\..\packages\razor4\Microsoft.AspNetCore.Razor\lib\net451\Microsoft.AspNetCore.Razor.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/source/RazorEngine.Core/RazorEngine.Core.csproj
+++ b/src/source/RazorEngine.Core/RazorEngine.Core.csproj
@@ -172,7 +172,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly Condition=" '$(Platform)' != 'Razor4' ">true</SignAssembly>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>RazorEngine.snk</AssemblyOriginatorKeyFile>

--- a/src/source/RazorEngine.Core/Templating/TemplateParsingException.cs
+++ b/src/source/RazorEngine.Core/Templating/TemplateParsingException.cs
@@ -5,7 +5,7 @@
     using System.Runtime.Serialization;
     using System.Security;
 #if RAZOR4
-    using Microsoft.AspNet.Razor.Parser.SyntaxTree;
+    using Microsoft.AspNetCore.Razor.Parser.SyntaxTree;
 #else
     using System.Web.Razor.Parser.SyntaxTree;
 #endif

--- a/src/source/RazorEngine.Core/paket.references
+++ b/src/source/RazorEngine.Core/paket.references
@@ -5,4 +5,4 @@ group Net40
   Microsoft.AspNet.Razor
 
 group Razor4
-  Microsoft.AspNet.Razor
+  Microsoft.AspNetCore.Razor

--- a/src/test/Test.RazorEngine.Core.Roslyn/RoslynCompilerTestFixture.cs
+++ b/src/test/Test.RazorEngine.Core.Roslyn/RoslynCompilerTestFixture.cs
@@ -181,7 +181,6 @@ namespace Test.RazorEngine.Core.Roslyn
         [Test]
         public void Roslyn_GetInformativeRuntimeErrorMessage()
         {
-            Assert.Ignore("Fixme: Include debug info in roslyn build");
             RunTestHelper(service =>
             {
                 const string template = "@foreach (var i in Model.Unknown) { @i }";

--- a/src/test/Test.RazorEngine.Core.Roslyn/Test.RazorEngine.Core.Roslyn.csproj
+++ b/src/test/Test.RazorEngine.Core.Roslyn/Test.RazorEngine.Core.Roslyn.csproj
@@ -58,6 +58,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|Razor4' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -69,6 +70,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|Razor4' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <RAZOR4>True</RAZOR4>

--- a/src/test/Test.RazorEngine.Core.Roslyn/Test.RazorEngine.Core.Roslyn.csproj
+++ b/src/test/Test.RazorEngine.Core.Roslyn/Test.RazorEngine.Core.Roslyn.csproj
@@ -81,7 +81,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly Condition=" '$(Platform)' != 'Razor4' ">true</SignAssembly>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>RazorEngine.snk</AssemblyOriginatorKeyFile>

--- a/src/test/Test.RazorEngine.Core/IsolatedRazorEngineServiceTestFixture.cs
+++ b/src/test/Test.RazorEngine.Core/IsolatedRazorEngineServiceTestFixture.cs
@@ -70,9 +70,6 @@ namespace Test.RazorEngine
         public static AppDomain SandboxCreator(IEnumerable<IPermission> permissions)
         {
             CheckMono();
-#if RAZOR4
-            Assert.Ignore("IsolatedRazorEngineServiceTestFixture is not tested with razor 4 as it is not signed!");
-#endif
 
 #if MONO
             // Mono has no AddHostEvidence or GetHostEvidence.
@@ -685,7 +682,11 @@ File.WriteAllText(""$file$"", ""BAD DATA"");
     var t = new TestHelper.TestClass();
 }
 @t.TestProperty";
+#if RAZOR4
+                const string expected = "\nTestPropert";
+#else
                 const string expected = "\n\nTestPropert";
+#endif
 
                 string result = service.RunCompile(template, "test");
 

--- a/src/test/Test.RazorEngine.Core/IsolatedRazorEngineServiceTestFixture.cs
+++ b/src/test/Test.RazorEngine.Core/IsolatedRazorEngineServiceTestFixture.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 using RazorEngine.Configuration;
 using RazorEngine.Compilation.ReferenceResolver;
 #if RAZOR4
-using Microsoft.AspNet.Razor;
+using Microsoft.AspNetCore.Razor;
 #else
 using System.Web.Razor;
 #endif

--- a/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
+++ b/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
@@ -66,6 +66,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|Razor4' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -78,6 +79,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|Razor4' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <RAZOR4>True</RAZOR4>
@@ -192,8 +194,8 @@
   <Choose>
     <When Condition="'$(RAZOR4)' == 'True' And ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1'))">
       <ItemGroup>
-        <Reference Include="Microsoft.AspNet.Razor">
-          <HintPath>..\..\..\packages\razor4\Microsoft.AspNet.Razor\lib\net45\Microsoft.AspNet.Razor.dll</HintPath>
+        <Reference Include="Microsoft.AspNetCore.Razor">
+          <HintPath>..\..\..\packages\razor4\Microsoft.AspNetCore.Razor\lib\net451\Microsoft.AspNetCore.Razor.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
+++ b/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
@@ -91,7 +91,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly Condition=" '$(Platform)' != 'Razor4' ">true</SignAssembly>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>RazorEngine.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
- razor version bump
- namespace changes
- require .net 4.5.1
- `Context.OnError` now takes an additional `length` argument
- `assemblyStream` and `pdbStream` need to be write- and readable
- update `TemplateBase` (new code taken from https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNetCore.Mvc.Razor/RazorPage.cs)
- debug info in stacktrace
- sign `RAZOR4` assemblies
- run isolated tests with `RAZOR4`