### PR TITLE
remove exact version match from Microsoft.AspNetCore.Razor dependency

### DIFF
--- a/buildConfig.fsx
+++ b/buildConfig.fsx
@@ -79,7 +79,7 @@ let buildConfig =
               Version = version_razor4
               ReleaseNotes = toLines release.Notes
               Dependencies =
-                [ "Microsoft.AspNetCore.Razor", "1.0" |> RequireExactly ] })
+                [ "Microsoft.AspNetCore.Razor", "1.0" ] })
         "RazorEngine.Roslyn.nuspec", (fun config p ->
           { p with
               Project = projectName_roslyn


### PR DESCRIPTION
note: there is also no exact version match for the RazorEngine.Roslyn package (see https://github.com/Antaris/RazorEngine/commit/8efee07d678ec3838e5a63f66e8de5ad1bb390bc)

fixes #427