### PR TITLE
Add a simple way to create typed, runnable templates

### DIFF
--- a/src/source/RazorEngine.Core/RazorEngine.Core.csproj
+++ b/src/source/RazorEngine.Core/RazorEngine.Core.csproj
@@ -279,11 +279,14 @@
     <Compile Include="Templating\DynamicWrapperService.cs" />
     <Compile Include="Templating\IsolatedRazorEngineService.cs" />
     <Compile Include="Templating\FullPathTemplateKey.cs" />
+    <Compile Include="Templating\ITemplateRunnerOfTModel.cs" />
     <Compile Include="Templating\ReferencesListForDynamicAssemblyResolution.cs" />
     <Compile Include="Templating\ResolvePathCheckModifiedTimeTemplateManager.cs" />
     <Compile Include="Templating\EmbeddedResourceTemplateManager.cs" />
     <Compile Include="Templating\ResolvePathTemplateManager.cs" />
     <Compile Include="Templating\TemplateLoadingException.cs" />
+    <Compile Include="Templating\TemplateRunnerExtensions.cs" />
+    <Compile Include="Templating\TemplateRunnerOfTModel.cs" />
     <Compile Include="Templating\WatchingResolvePathTemplateManager.cs" />
     <Compile Include="Templating\WrapperTemplateManager.cs" />
     <Compile Include="Configuration\Xml\XmlTemplateServiceConfiguration.cs" />

--- a/src/source/RazorEngine.Core/Templating/ITemplateRunnerOfTModel.cs
+++ b/src/source/RazorEngine.Core/Templating/ITemplateRunnerOfTModel.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+
+namespace RazorEngine.Templating
+{
+    /// <summary>
+    /// Defines the required contract for implementing a typed, runnable template reference.
+    /// </summary>
+    /// <typeparam name="TModel">The model type</typeparam>
+    public interface ITemplateRunner<TModel>
+    {
+        /// <summary>
+        /// Runs the template using the specified <paramref name="model"/>.
+        /// </summary>
+        /// <param name="model"></param>
+        /// <param name="textWriter"></param>
+        /// <param name="viewBag"></param>
+        void Run(TModel model, TextWriter textWriter, DynamicViewBag viewBag = null);
+    }
+}

--- a/src/source/RazorEngine.Core/Templating/RazorEngineServiceExtensions.cs
+++ b/src/source/RazorEngine.Core/Templating/RazorEngineServiceExtensions.cs
@@ -369,5 +369,36 @@ namespace RazorEngine.Templating
         {
             return WithWriter(writer => service.Run(name, writer, modelType, model, viewBag));
         }
+
+        /// <summary>
+        /// Adds and compiles a new template using the specified <paramref name="templateSource"/> and returns a <see cref="TemplateRunner{TModel}"/>.
+        /// </summary>
+        /// <typeparam name="TModel">The model type</typeparam>
+        /// <param name="service"></param>
+        /// <param name="templateSource"></param>
+        /// <returns></returns>
+        public static ITemplateRunner<TModel> CompileRunner<TModel>(this IRazorEngineService service, string templateSource)
+        {
+            var name = $"{typeof(TModel).Name}_{Guid.NewGuid()}";
+            return service.CompileRunner<TModel>(templateSource, name);
+        }
+
+        /// <summary>
+        /// Adds and compiles a new template using the specified <paramref name="templateSource"/> and returns a <see cref="TemplateRunner{TModel}"/>.
+        /// </summary>
+        /// <typeparam name="TModel">The model type</typeparam>
+        /// <param name="service"></param>
+        /// <param name="templateSource"></param>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static ITemplateRunner<TModel> CompileRunner<TModel>(this IRazorEngineService service, string templateSource, string name)
+        {
+            var key = service.GetKey(name);
+
+            service.AddTemplate(key, templateSource);
+            service.Compile(key, typeof(TModel));
+
+            return new TemplateRunner<TModel>(service, key);
+        }
     }
 }

--- a/src/source/RazorEngine.Core/Templating/TemplateRunnerExtensions.cs
+++ b/src/source/RazorEngine.Core/Templating/TemplateRunnerExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+
+namespace RazorEngine.Templating
+{
+    /// <summary>
+    /// Extensions for the <see cref="ITemplateRunner{TModel}"/>.
+    /// </summary>
+    public static class TemplateRunnerExtensions
+    {
+        /// <summary>
+        /// Runs the template using the specified <paramref name="model"/>.
+        /// </summary>
+        /// <param name="templateRunner"></param>
+        /// <param name="model"></param>
+        /// <param name="viewBag"></param>
+        /// <returns></returns>
+        public static string Run<TModel>(this ITemplateRunner<TModel> templateRunner, TModel model, DynamicViewBag viewBag = null)
+        {
+            using (var textWriter = new StringWriter())
+            {
+                templateRunner.Run(model, textWriter, viewBag);
+                return textWriter.ToString();
+            }
+        }
+    }
+}

--- a/src/source/RazorEngine.Core/Templating/TemplateRunnerOfTModel.cs
+++ b/src/source/RazorEngine.Core/Templating/TemplateRunnerOfTModel.cs
@@ -1,0 +1,36 @@
+﻿using System.IO;
+
+namespace RazorEngine.Templating
+{
+    /// <summary>
+    /// Typed, runnable template reference.
+    /// </summary>
+    /// <typeparam name="TModel">The model type</typeparam>
+    internal class TemplateRunner<TModel> : ITemplateRunner<TModel>
+    {
+        private readonly IRazorEngineService _service;
+        private readonly ITemplateKey _key;
+
+        /// <summary>
+        /// Initialises a new instance of <see cref="TemplateRunner{TModel}"/>.
+        /// </summary>
+        /// <param name="service"></param>
+        /// <param name="key"></param>
+        public TemplateRunner(IRazorEngineService service, ITemplateKey key)
+        {
+            _service = service;
+            _key = key;
+        }
+
+        /// <summary>
+        /// Runs the template using the specified <paramref name="model"/>.
+        /// </summary>
+        /// <param name="model"></param>
+        /// <param name="textWriter"></param>
+        /// <param name="viewBag"></param>
+        public void Run(TModel model, TextWriter textWriter, DynamicViewBag viewBag = null)
+        {
+            _service.Run(_key, textWriter, typeof(TModel), model, viewBag);
+        }
+    }
+}

--- a/src/test/Test.RazorEngine.Core/Templating/TemplateRunnerTestFixture.cs
+++ b/src/test/Test.RazorEngine.Core/Templating/TemplateRunnerTestFixture.cs
@@ -1,0 +1,52 @@
+﻿using System.IO;
+using NUnit.Framework;
+using RazorEngine.Configuration;
+using RazorEngine.Templating;
+using RazorEngine.Tests.TestTypes;
+
+namespace Test.RazorEngine.Templating
+{
+    /// <summary>
+    /// Defines a test fixture that provides tests for the <see cref="TemplateRunner{TModel}"/> type.
+    /// </summary>
+    [TestFixture]
+    public class TemplateRunnerTestFixture
+    {
+        /// <summary>
+        /// Tests that the template runner can run the template.
+        /// </summary>
+        [Test]
+        public void TemplateRunner_CanRunTemplateString()
+        {
+            const string template = "Hello @Model.Forename, welcome to RazorEngine!";
+
+            var configuration = new TemplateServiceConfiguration { Debug = true };
+            using (var service = RazorEngineService.Create(configuration))
+            {
+                var runner = service.CompileRunner<Person>(template);
+                var output = runner.Run(new Person { Forename = "Max" });
+
+                Assert.AreEqual("Hello Max, welcome to RazorEngine!", output);
+            }
+        }
+
+        /// <summary>
+        /// Tests that the template runner can run the template on a text writer.
+        /// </summary>
+        [Test]
+        public void TemplateRunner_CanRunTemplateTextWriter()
+        {
+            const string template = "Hello @Model.Forename, welcome to RazorEngine!";
+
+            var configuration = new TemplateServiceConfiguration { Debug = true };
+            using (var service = RazorEngineService.Create(configuration))
+            using (var writer = new StringWriter())
+            {
+                var runner = service.CompileRunner<Person>(template);
+                runner.Run(new Person { Forename = "Max" }, writer);
+
+                Assert.AreEqual("Hello Max, welcome to RazorEngine!", writer.ToString());
+            }
+        }
+    }
+}

--- a/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
+++ b/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
@@ -108,6 +108,7 @@
     <Compile Include="CompilerServicesUtilityTestFixture.cs" />
     <Compile Include="RazorEngineCleanupTests.cs" />
     <Compile Include="Templating\EmbeddedResourceTemplateManagerTestFixture.cs" />
+    <Compile Include="Templating\TemplateRunnerTestFixture.cs" />
     <Compile Include="Templating\Templates\Model.cs" />
     <Compile Include="TestTypes\BaseTypes\AddLanguageInfo.cs" />
     <Compile Include="TestTypes\BaseTypes\NestedBaseClass.cs" />


### PR DESCRIPTION
Hello,

It is often required to compile a template from a string, and then use it several times. For instance:
```cs
// once on startup
Engine.Razor.Compile(File.ReadAllText(templatePath), "MyKey", typeof(MyModel));
// then
var output = Engine.Razor.Run("MyKey", typeof(MyModel), model);
```

This PR adds a simple way to register typed runnable templates:
```cs
// once on startup
_templateRunner = Engine.Razor.CompileRunner<MyModel>(File.ReadAllText(templatePath));
// then
var output = _templateRunner.Run(model);
```