### PR TITLE
fixed issue with Assembly.Location throwing

### DIFF
--- a/src/source/RazorEngine.Core/Compilation/ReferenceResolver/UseCurrentAssembliesReferenceResolver.cs
+++ b/src/source/RazorEngine.Core/Compilation/ReferenceResolver/UseCurrentAssembliesReferenceResolver.cs
@@ -22,10 +22,23 @@ namespace RazorEngine.Compilation.ReferenceResolver
         {
             return CompilerServicesUtility
                    .GetLoadedAssemblies()
-                   .Where(a => !a.IsDynamic && File.Exists(a.Location) && !a.Location.Contains(CompilerServiceBase.DynamicTemplateNamespace))
+                   .Where(IsValidAssembly)
                    .GroupBy(a => a.GetName().Name).Select(grp => grp.First(y => y.GetName().Version == grp.Max(x => x.GetName().Version))) // only select distinct assemblies based on FullName to avoid loading duplicate assemblies
                    .Select(a => CompilerReference.From(a))
                    .Concat(includeAssemblies ?? Enumerable.Empty<CompilerReference>());
         }
+
+        private static bool IsValidAssembly(System.Reflection.Assembly a)
+        {
+            try
+            {
+                return !a.IsDynamic && File.Exists(a.Location) && !a.Location.Contains(CompilerServiceBase.DynamicTemplateNamespace);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Assembly.Location could throw. In my case, I am trying to use RazorEngine in an Azure Function, which loads some native Edge dlls for JavaScript interop. These assemblies are loaded into the domain, however, calling Assembly.Location on them throws an exception.

I was thinking to use a custom resolver, however, this code is also used in the exceptions, and it is not trivial to use the custom resolver in the exception constructors. Hence such quick fix.