### PR TITLE
Update Obsolete tests to use RazorEngineService

### DIFF
--- a/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
+++ b/src/source/RazorEngine.Core/Compilation/CompilerServiceBase.cs
@@ -417,7 +417,12 @@
         /// <param name="disposing">true when Dispose() was called manually.</param>
         protected virtual void Dispose(bool disposing)
         {
+            if (_disposed)
+            {
+                return;
+            }
 
+            _disposed = true;
         }
 
         #endregion

--- a/src/test/Test.RazorEngine.Core/ActivatorTestFixture.cs
+++ b/src/test/Test.RazorEngine.Core/ActivatorTestFixture.cs
@@ -46,15 +46,13 @@
                                  BaseTemplateType = typeof(CustomTemplateBase<>)
                              };
 
-#pragma warning disable 0618 // Fine because we still want to test if
-            using (var service = new TemplateService(config))
-#pragma warning restore 0618 // Fine because we still want to test if
+            using (var service = RazorEngineService.Create(config))
             {
                 const string template = "<h1>Hello @Format(Model.Forename)</h1>";
                 const string expected = "<h1>Hello ttaM</h1>";
 
                 var model = new Person { Forename = "Matt" };
-                string result = service.Parse(template, model, null, null);
+                string result = service.RunCompile(templateSource: template, name: "template", model: model);
 
                 Assert.That(result == expected, "Result does not match expected: " + result);
             }

--- a/src/test/Test.RazorEngine.Core/CodeInspectorTestFixture.cs
+++ b/src/test/Test.RazorEngine.Core/CodeInspectorTestFixture.cs
@@ -27,11 +27,11 @@
             var config = new TemplateServiceConfiguration();
             config.CodeInspectors.Add(new ThrowExceptionCodeInspector());
 
-            using (var service = new TemplateService(config))
+            using (var service = RazorEngineService.Create(config))
             {
                 const string template = "Hello World";
 
-                Assert.Throws<InvalidOperationException>(() => service.Parse(template, null, null, null));
+                Assert.Throws<InvalidOperationException>(() => service.RunCompile(templateSource: template, name: "template"));
             }
         }
         #endregion

--- a/src/test/Test.RazorEngine.Core/ConfigurationTestFixture.cs
+++ b/src/test/Test.RazorEngine.Core/ConfigurationTestFixture.cs
@@ -38,15 +38,19 @@
         {
             var config = new FluentTemplateServiceConfiguration(
                 c => c.IncludeNamespaces("System.IO"));
-#pragma warning disable 0618 // TODO: Update test.
-            using (var service = new TemplateService(config))
-#pragma warning restore 0618 // TODO: Update test.
+            using (var service = RazorEngineService.Create(config))
+            using (var writer = new StringWriter())
             {
                 const string template = @"@Directory.GetFiles(Path.GetPathRoot(Environment.GetFolderPath(Environment.SpecialFolder.Personal)), ""*.*"").Length";
 
                 int expected = Directory.GetFiles(Path.GetPathRoot(Environment.GetFolderPath(Environment.SpecialFolder.Personal)), "*.*").Length;
-                string result = service.Parse(template, null, null, null);
 
+                var key = service.GetKey("testTemplate");
+                var source = new LoadedTemplateSource(template);
+                service.AddTemplate(key, source);
+                service.Compile(key);
+                service.Run(key, writer);
+                var result = writer.ToString();
                 Assert.AreEqual(expected.ToString(), result);
             }
         }
@@ -74,14 +78,12 @@
             var config = new FluentTemplateServiceConfiguration(
                 c => c.WithCodeLanguage(Language.VisualBasic));
 
-#pragma warning disable 0618 // TODO: Update test.
-            using (var service = new TemplateService(config))
-#pragma warning restore 0618 // TODO: Update test.
+            using (var service = RazorEngineService.Create(config))
             {
                 const string template = "@Code Dim name As String = \"Matt\" End Code\n@name";
                 const string expected = "\nMatt";
 
-                string result = service.Parse(template, null, null, null);
+                string result = service.RunCompile(templateSource: template, name: "template");
 
                 Assert.That(result == expected, "Result does not match expected: " + result);
             }
@@ -97,17 +99,22 @@
             var config = new FluentTemplateServiceConfiguration(
                 c => c.WithEncoding(Encoding.Raw));
 
-#pragma warning disable 0618 // TODO: Update test.
-            using (var service = new TemplateService(config))
-#pragma warning restore 0618 // TODO: Update test.
+            using (var service = RazorEngineService.Create(config))
+            using (var writer = new StringWriter())
             {
                 const string template = "<h1>Hello @Model.String</h1>";
                 const string expected = "<h1>Hello Matt & World</h1>";
 
                 var model = new { String = "Matt & World" };
-                string result = service.Parse(template, model, null, null);
+                var source = new LoadedTemplateSource(template);
+                var key = service.GetKey("testTemplate");
 
-                Assert.That(result == expected, "Result does not match expected: " + result);
+                service.Compile(source, key);
+                service.Run(key, writer, model: model);
+
+                var contents = writer.ToString();
+
+                Assert.AreEqual(expected, contents);
             }
         }
 


### PR DESCRIPTION
* This updates the tests that were marked obsolete to use RazorEngineService instead of the TemplateService.
* This fixes the warning in CompilerServiceBase.cs about `_disposed` being unused by using it in part of the IDisposable pattern.

Part of changes to support #414