### PR TITLE
Properly unload cleanup helper app domain after an isolated service is disposed

### DIFF
--- a/src/source/RazorEngine.Core/Compilation/CrossAppDomainCleanUp.cs
+++ b/src/source/RazorEngine.Core/Compilation/CrossAppDomainCleanUp.cs
@@ -365,7 +365,7 @@ namespace RazorEngine.Compilation
                         }
                     }
                     // We are not needed anymore.
-                    //AppDomain.Unload(AppDomain.CurrentDomain);
+                    AppDomain.Unload(AppDomain.CurrentDomain);
                 });
                 t.IsBackground = false;
                 t.Start();

--- a/src/test/Test.RazorEngine.Core/RazorEngineCleanupTests.cs
+++ b/src/test/Test.RazorEngine.Core/RazorEngineCleanupTests.cs
@@ -105,56 +105,59 @@ namespace Test.RazorEngine
             Assert.IsFalse(Directory.Exists(folder));
         }
 
-        [Serializable]
-        public class TemplateModel
-        {
-            public string Name { get; set; }
-        }
+        // The test below requires a COM object to run that is not available on the CI server.
+        // To run, add the following as a COM reference to the project: - C:\WINDOWS\Microsoft.NET\Framework\vXXXXXX\mscoree.tlb
 
-        [Test]
-        public void RazorEngineService_CleanupDomainIsUnloaded()
-        {
-            Func<bool> CleanupDomainExists = () =>
-              GetAppDomains()
-                .Any(x => x.FriendlyName.StartsWith("CleanupHelperDomain_"));
+        //[Serializable]
+        //public class TemplateModel
+        //{
+        //    public string Name { get; set; }
+        //}
 
-            Assert.False(CleanupDomainExists(), "Cleanup helper app domain should not exist before test is run.");
-            using (var service = IsolatedRazorEngineService.Create())
-            {
-                service.AddTemplate("TestTemplate",
-                  "Hello @Model.Name " + new String(Enumerable.Repeat('A', 100000).ToArray()));
-                service.Compile("TestTemplate", typeof(TemplateModel));
+        //[Test]
+        //public void RazorEngineService_CleanupDomainIsUnloaded()
+        //{
+        //    Func<bool> CleanupDomainExists = () =>
+        //      GetAppDomains()
+        //        .Any(x => x.FriendlyName.StartsWith("CleanupHelperDomain_"));
 
-                Assert.True(CleanupDomainExists(), "Cleanup helper app domain should exist after a template is compiled");
-            }
+        //    Assert.False(CleanupDomainExists(), "Cleanup helper app domain should not exist before test is run.");
+        //    using (var service = IsolatedRazorEngineService.Create())
+        //    {
+        //        service.AddTemplate("TestTemplate",
+        //          "Hello @Model.Name " + new String(Enumerable.Repeat('A', 100000).ToArray()));
+        //        service.Compile("TestTemplate", typeof(TemplateModel));
 
-            Thread.Sleep(300);
-            Assert.False(CleanupDomainExists(), "Cleanup helper app domain must be properly unloaded after service is disposed");
-        }
+        //        Assert.True(CleanupDomainExists(), "Cleanup helper app domain should exist after a template is compiled");
+        //    }
 
-        private static IList<AppDomain> GetAppDomains()
-        {
-            IList<AppDomain> _IList = new List<AppDomain>();
-            IntPtr enumHandle = IntPtr.Zero;
-            mscoree.ICorRuntimeHost host = new mscoree.CorRuntimeHost();
-            try
-            {
-                host.EnumDomains(out enumHandle);
-                object domain = null;
-                while (true)
-                {
-                    host.NextDomain(enumHandle, out domain);
-                    if (domain == null) break;
-                    AppDomain appDomain = (AppDomain)domain;
-                    _IList.Add(appDomain);
-                }
-                return _IList;
-            }
-            finally
-            {
-                host.CloseEnum(enumHandle);
-                Marshal.ReleaseComObject(host);
-            }
-        }
+        //    Thread.Sleep(300);
+        //    Assert.False(CleanupDomainExists(), "Cleanup helper app domain must be properly unloaded after service is disposed");
+        //}
+
+        //private static IList<AppDomain> GetAppDomains()
+        //{
+        //    IList<AppDomain> _IList = new List<AppDomain>();
+        //    IntPtr enumHandle = IntPtr.Zero;
+        //    mscoree.ICorRuntimeHost host = new mscoree.CorRuntimeHost();
+        //    try
+        //    {
+        //        host.EnumDomains(out enumHandle);
+        //        object domain = null;
+        //        while (true)
+        //        {
+        //            host.NextDomain(enumHandle, out domain);
+        //            if (domain == null) break;
+        //            AppDomain appDomain = (AppDomain)domain;
+        //            _IList.Add(appDomain);
+        //        }
+        //        return _IList;
+        //    }
+        //    finally
+        //    {
+        //        host.CloseEnum(enumHandle);
+        //        Marshal.ReleaseComObject(host);
+        //    }
+        //}
     }
 }

--- a/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
+++ b/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
@@ -164,6 +164,17 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <COMReference Include="mscoree">
+      <Guid>{5477469E-83B1-11D2-8B49-00A0C9B7C9C4}</Guid>
+      <VersionMajor>2</VersionMajor>
+      <VersionMinor>4</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>tlbimp</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
   <Import Project="$(CSharpTargetsPath)" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
+++ b/src/test/Test.RazorEngine.Core/Test.RazorEngine.Core.csproj
@@ -164,17 +164,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <COMReference Include="mscoree">
-      <Guid>{5477469E-83B1-11D2-8B49-00A0C9B7C9C4}</Guid>
-      <VersionMajor>2</VersionMajor>
-      <VersionMinor>4</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
   <Import Project="$(CSharpTargetsPath)" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Fixes #492. A small unittest is provided to demonstrate the issue.