### PR TITLE
Support exchanging values on DynamicViewBag across AppDomains

### DIFF
--- a/src/source/RazorEngine.Core/Common/CrossAppDomainDictionary.cs
+++ b/src/source/RazorEngine.Core/Common/CrossAppDomainDictionary.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace RazorEngine.Common
+{
+    internal class CrossAppDomainDictionary<TKey, TValue> : CrossAppDomainObject, IDictionary<TKey, TValue>
+    {
+        #region Fields
+
+        private readonly IDictionary<TKey, TValue> _dict;
+
+        #endregion
+
+        #region Constructor
+
+        public CrossAppDomainDictionary()
+        {
+            _dict = new Dictionary<TKey, TValue>();
+        }
+
+        public CrossAppDomainDictionary(int capacity)
+        {
+            _dict = new Dictionary<TKey, TValue>(capacity);
+        }
+
+        public CrossAppDomainDictionary(IEqualityComparer<TKey> comparer)
+        {
+            _dict = new Dictionary<TKey, TValue>(comparer);
+        }
+
+        public CrossAppDomainDictionary(IDictionary<TKey, TValue> dictionary)
+        {
+            _dict = new Dictionary<TKey, TValue>(dictionary);
+        }
+
+        public CrossAppDomainDictionary(int capacity, IEqualityComparer<TKey> comparer)
+        {
+            _dict = new Dictionary<TKey, TValue>(capacity, comparer);
+        }
+
+        public CrossAppDomainDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer)
+        {
+            _dict = new Dictionary<TKey, TValue>(dictionary, comparer);
+        }
+
+        #endregion
+
+        #region Properties
+
+        public TValue this[TKey key] { get { return _dict[key]; } set { _dict[key] = value; } }
+
+        public ICollection<TKey> Keys { get { return _dict.Keys; } }
+
+        public ICollection<TValue> Values { get { return _dict.Values; } }
+
+        public int Count { get { return _dict.Count; } }
+
+        public bool IsReadOnly { get { return _dict.IsReadOnly; } }
+
+        #endregion
+
+        #region Methods
+
+        public void Add(TKey key, TValue value)
+        {
+            _dict.Add(key, value);
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            _dict.Add(item);
+        }
+
+        public void Clear()
+        {
+            _dict.Clear();
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return _dict.Contains(item);
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            return _dict.ContainsKey(key);
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            _dict.CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return _dict.GetEnumerator();
+        }
+
+        public bool Remove(TKey key)
+        {
+            return _dict.Remove(key);
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return _dict.Remove(item);
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            return _dict.TryGetValue(key, out value);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _dict.GetEnumerator();
+        }
+
+        #endregion
+    }
+}

--- a/src/source/RazorEngine.Core/RazorEngine.Core.csproj
+++ b/src/source/RazorEngine.Core/RazorEngine.Core.csproj
@@ -208,6 +208,7 @@
   <ItemGroup>
     <Compile Include="AttributeValue.cs" />
     <Compile Include="CodeGenerators\SetModelTypeCodeGenerator.cs" />
+    <Compile Include="Common\CrossAppDomainDictionary.cs" />
     <Compile Include="Compilation\CompilerServiceBase.cs" />
     <Compile Include="Compilation\CompilerServiceBuilder.cs" />
     <Compile Include="Compilation\CompilerServicesUtility.cs" />

--- a/src/source/RazorEngine.Core/Templating/DynamicViewBag.cs
+++ b/src/source/RazorEngine.Core/Templating/DynamicViewBag.cs
@@ -1,5 +1,6 @@
 ﻿namespace RazorEngine.Templating
 {
+    using RazorEngine.Common;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -13,7 +14,7 @@
     {
         #region Fields
         private readonly IDictionary<string, object> _dict = 
-            new System.Collections.Generic.Dictionary<string, object>();
+            new CrossAppDomainDictionary<string, object>();
         #endregion
         /// <summary>
         /// Create a new DynamicViewBag.

--- a/src/test/Test.RazorEngine.Core/IsolatedRazorEngineServiceTestFixture.cs
+++ b/src/test/Test.RazorEngine.Core/IsolatedRazorEngineServiceTestFixture.cs
@@ -143,6 +143,23 @@ namespace Test.RazorEngine
         }
 
         /// <summary>
+        /// Tests that exchanging values on the viewbag works across app domains
+        /// </summary>
+        [Test]
+        public void IsolatedRazorEngineService_DynamicViewBag_FromSandBox()
+        {
+            using (var service = IsolatedRazorEngineService.Create(SandboxCreator))
+            {
+                const string template = "@{ ViewBag.Test = \"TestItem\"; }";
+                const string expected = "TestItem";
+                dynamic viewbag = new DynamicViewBag();
+
+                string result = service.RunCompile(template, "test", (Type)null, (object)null, (DynamicViewBag)viewbag);
+                Assert.AreEqual(expected, viewbag.Test);
+            }
+        }
+
+        /// <summary>
         /// Tests that a simple viewbag is working.
         /// </summary>
         [Test]


### PR DESCRIPTION
Before the `DynamicViewBag` was serialized into the isolated app domain which disconnected it from the original app domain. So if values were set onto the `@ViewBag` inside the template they were not available in the original app domain.

By using a custom dictionary implementation which inherits from `MarshalByRefObject` the values set in the isolated app domain are available in the original app domain.

fixes #487