### PR TITLE
Fix event args generation for FileSystemWatcher of the WatchingResolvePathTemplateManager

### DIFF
--- a/src/source/RazorEngine.Core/Templating/WatchingResolvePathTemplateManager.cs
+++ b/src/source/RazorEngine.Core/Templating/WatchingResolvePathTemplateManager.cs
@@ -83,8 +83,8 @@ namespace RazorEngine.Templating
 
         void watcher_Renamed(object sender, RenamedEventArgs e)
         {
-            watcher_Changed(sender, new FileSystemEventArgs(WatcherChangeTypes.Deleted, e.OldFullPath, e.OldName));
-            watcher_Changed(sender, new FileSystemEventArgs(WatcherChangeTypes.Created, e.FullPath, e.Name));
+            watcher_Changed(sender, new FileSystemEventArgs(WatcherChangeTypes.Deleted, Path.GetDirectoryName(e.OldFullPath) ?? e.OldFullPath, e.OldName));
+            watcher_Changed(sender, new FileSystemEventArgs(WatcherChangeTypes.Created, Path.GetDirectoryName(e.FullPath) ?? e.FullPath, e.Name));
         }
 
         /// <summary>


### PR DESCRIPTION
The FileSystemEventArgs takes as argument the directory path, not the full path to the file: 
https://docs.microsoft.com/en-us/dotnet/api/system.io.filesystemeventargs.-ctor?view=netframework-4.7.2
I tried to use WatchingResolvePathTemplateManager for debugging, but when you change template in Visual Studio it actually fires 7 events, for example (not exactly in that order): 

1. Created "DirectoryPath\vfg3ps5n.nrj~"
2. Created "DirectoryPath\Filename.cshtml~RF432f4415.TMP"
3. Deleted "DirectoryPath\Filename.cshtml~RF432f4415.TMP"
4. Renamed "DirectoryPath\Filename.cshtml" -> "DirectoryPath\\Filename.cshtml~RF432f4415.TMP"
5. Renamed "DirectoryPath\vfg3ps5n.nrj~" -> "DirectoryPath\Filename.cshtml"
6. Changed "DirectoryPath\vfg3ps5n.nrj~"
7. Deleted "DirectoryPath\Filename.cshtml~RF432f4415.TMP"

So if we are looking for DirectoryPath\Filename.cshtml, it will be mentioned only in 'Renamed' event.
But it was not working correctly, because of wrong FileEventArgs parameters.