### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ static int Main(string[] args)
             "MyMainDomain", null,
             current.SetupInformation, new PermissionSet(PermissionState.Unrestricted),
             strongNames);
-        var exitCode = domain.ExecuteAssembly(Assembly.GetExecutingAssembly().Location);
+        var exitCode = domain.ExecuteAssembly(Assembly.GetExecutingAssembly().Location, args);
         // RazorEngine will cleanup. 
         AppDomain.Unload(domain);
         return exitCode;


### PR DESCRIPTION
when changing the app domain, the current assembly is restarted in a new domain.
The original application arguments need to be forwarded to the new execution.